### PR TITLE
Std library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,17 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cxxopts)
 
 target_link_libraries(neutronium_lib PRIVATE cxxopts)
+
+# === magic_enum setup ===
+FetchContent_Declare(
+        magic_enum
+        GIT_REPOSITORY https://github.com/Neargye/magic_enum.git
+        GIT_TAG v0.9.5
+)
+FetchContent_MakeAvailable(magic_enum)
+
+target_link_libraries(neutronium_lib PRIVATE magic_enum)
+
 target_link_libraries(neutronium PRIVATE neutronium_lib)
 
 # === GoogleTest setup ===

--- a/Neutronium.tmbundle/Syntaxes/Neutronium.tmLanguage.json
+++ b/Neutronium.tmbundle/Syntaxes/Neutronium.tmLanguage.json
@@ -47,7 +47,7 @@
       "patterns": [
         {
           "name": "keyword.control.neutronium",
-          "match": "\\b(if|elif|else|while|exit|fn|extern|break|continue|let|mut|const|return|export|import)\\b"
+          "match": "\\b(if|elif|else|while|exit|fn|extern|break|continue|let|mut|const|return|export)\\b"
         }
       ]
     },

--- a/Neutronium.tmbundle/Syntaxes/Neutronium.tmLanguage.json
+++ b/Neutronium.tmbundle/Syntaxes/Neutronium.tmLanguage.json
@@ -47,7 +47,7 @@
       "patterns": [
         {
           "name": "keyword.control.neutronium",
-          "match": "\\b(if|elif|else|while|exit|fn|extern|break|continue|let|mut|const|return)\\b"
+          "match": "\\b(if|elif|else|while|exit|fn|extern|break|continue|let|mut|const|return|export|import)\\b"
         }
       ]
     },

--- a/cmake-build.sh
+++ b/cmake-build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+set -euo pipefail
+
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug "$@" .
 cmake --build build

--- a/compile.sh
+++ b/compile.sh
@@ -1,7 +1,6 @@
-set -e  # exit immediately if a command exits with a non-zero status
+#!/bin/bash
+set -euo pipefail
 
 ./cmake-build.sh
 
 ./build/neutronium "$@"
-
-set +e  # disable immediate exit on failure

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
+
+enum class TargetType : uint8_t {
+    EXECUTABLE,
+    LIBRARY,
+};
 
 struct CompilerOptions {
     bool logCode_ = false;
@@ -8,6 +14,7 @@ struct CompilerOptions {
     bool logAst_ = false;
     bool logAssembly_ = false;
     std::string sourceFilename_;
+    TargetType targetType_ = TargetType::EXECUTABLE;
 };
 
 CompilerOptions parse_cli(int argc, char** argv);

--- a/include/generation/generator.hpp
+++ b/include/generation/generator.hpp
@@ -3,17 +3,21 @@
 #include <sstream>
 #include <string>
 
+#include "cli.hpp"
 #include "semantic-analysis/symbol_table.hpp"
 
 class Generator {
    public:
-    explicit Generator(const AST::Program& ast) : program_(ast) {}
+    explicit Generator(const AST::Program& ast, const TargetType targetType)
+        : program_(ast), targetType_(targetType) {}
 
     [[nodiscard]] std::stringstream generate();
 
    private:
     const AST::Program& program_;
     std::stringstream output_;
+
+    const TargetType targetType_;
 
     int labelsCount_ = 0;
     int innerLoopStartLabel_ = 0;

--- a/include/lexing/token_kind.hpp
+++ b/include/lexing/token_kind.hpp
@@ -48,6 +48,7 @@ enum class TokenKind : uint8_t {
     CONTINUE,
     FN,
     EXTERN,
+    EXPORT,
     RETURN,
     EXIT,
 

--- a/include/parsing/ast.hpp
+++ b/include/parsing/ast.hpp
@@ -236,16 +236,19 @@ struct ExternalFunctionDeclaration final : Node {
 struct FunctionDefinition final : Node {
     FunctionDefinition(std::unique_ptr<Identifier> identifier,
                        std::vector<std::unique_ptr<VariableDefinition>> parameters,
-                       const Type returnType, std::unique_ptr<BlockStatement> body)
+                       const Type returnType, const bool isExported,
+                       std::unique_ptr<BlockStatement> body)
         : Node{NodeKind::FUNCTION_DEFINITION},
           identifier_(std::move(identifier)),
           parameters_(std::move(parameters)),
           returnType_(returnType),
+          isExported_(isExported),
           body_(std::move(body)) {}
 
     std::unique_ptr<Identifier> identifier_;
     const std::vector<std::unique_ptr<VariableDefinition>> parameters_;
     const Type returnType_;
+    const bool isExported_;
     std::unique_ptr<BlockStatement> body_;
 };
 

--- a/include/semantic-analysis/semantic_analyser.hpp
+++ b/include/semantic-analysis/semantic_analyser.hpp
@@ -3,18 +3,21 @@
 #include <string>
 #include <vector>
 
+#include "cli.hpp"
 #include "parsing/ast.hpp"
 #include "semantic-analysis/symbol_table.hpp"
 #include "semantic-analysis/type.hpp"
 
 class SemanticAnalyser {
    public:
-    explicit SemanticAnalyser(const AST::Program& ast) : ast_(&ast) {}
+    explicit SemanticAnalyser(const AST::Program& ast, const TargetType targetType)
+        : ast_(&ast), targetType_(targetType) {}
 
     void analyse();
 
    private:
     const AST::Program* ast_;
+    const TargetType targetType_;
 
     std::vector<SymbolTable> scopes_;
     SymbolTable functionsTable_;

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
-set -e
 ./compile.sh "$@"
+
 set +e
 
 ./neutro/out

--- a/runtime/io.asm
+++ b/runtime/io.asm
@@ -1,11 +1,11 @@
 section .text
-global func_print_c
-global func_print_num
+global __print_c
+global __print_num
 
 ; ------------------------------------------------
 ; fn print_c(char: int);
 ; ------------------------------------------------
-func_print_c:
+__print_c:
     mov rax, [rsp + 8]    ; load full int64 argument
     push rax              ; store it on the stack (temporary buffer)
 
@@ -22,7 +22,7 @@ func_print_c:
 ; ------------------------------------------------
 ; fn print_num(num: int);
 ; ------------------------------------------------
-func_print_num:
+__print_num:
     push    rbp
     mov     rbp, rsp
 
@@ -56,7 +56,7 @@ func_print_num:
 
     pop     rdx                ; get ASCII digit
     push    rdx
-    call    func_print_c
+    call    __print_c          ; print the digit
     pop     rdx
     jmp     .print_digits
 

--- a/runtime/math.nt
+++ b/runtime/math.nt
@@ -1,0 +1,3 @@
+export fn mod(a: int, b: int) -> int: {
+    return a - (a / b) * b;
+}

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -11,11 +11,10 @@ CompilerOptions parse_cli(int argc, char** argv) {
     options.positional_help("<input-file>").show_positional_help();
 
     options.add_options()("h,help", "Print help")("v,version", "Print the compiler version")(
-        "target-type", "Compilation target: bin or lib",
-        cxxopts::value<std::string>()->default_value("bin"))(
-        "d,debug", "Enable all debug logs")("log-code", "Log source code processing")(
-        "log-tokens", "Log token stream")("log-ast", "Log AST construction")(
-        "log-assembly", "Log final assembly output")(
+        "target-type", "Compilation target: bin (executable) or lib (library)",
+        cxxopts::value<std::string>()->default_value("bin"))("d,debug", "Enable all debug logs")(
+        "log-code", "Log source code processing")("log-tokens", "Log token stream")(
+        "log-ast", "Log AST construction")("log-assembly", "Log final assembly output")(
         "log", "Comma-separated logs (code,tokens,ast,assembly)",
         cxxopts::value<std::vector<std::string>>()->implicit_value(""))(
         "input", "Source file", cxxopts::value<std::string>());
@@ -48,9 +47,9 @@ CompilerOptions parse_cli(int argc, char** argv) {
     opts.logAssembly_ = result.count("log-assembly");
 
     const std::string targetType = result["target-type"].as<std::string>();
-    if (targetType == "bin") {
+    if (targetType == "bin" || targetType == "executable") {
         opts.targetType_ = TargetType::EXECUTABLE;
-    } else if (targetType == "lib") {
+    } else if (targetType == "lib" || targetType == "library") {
         opts.targetType_ = TargetType::LIBRARY;
     } else {
         print_error(std::format("Unknown target type: '{}'", targetType));

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -11,6 +11,8 @@ CompilerOptions parse_cli(int argc, char** argv) {
     options.positional_help("<input-file>").show_positional_help();
 
     options.add_options()("h,help", "Print help")("v,version", "Print the compiler version")(
+        "target-type", "Compilation target: bin or lib",
+        cxxopts::value<std::string>()->default_value("bin"))(
         "d,debug", "Enable all debug logs")("log-code", "Log source code processing")(
         "log-tokens", "Log token stream")("log-ast", "Log AST construction")(
         "log-assembly", "Log final assembly output")(
@@ -44,6 +46,17 @@ CompilerOptions parse_cli(int argc, char** argv) {
     opts.logTokens_ = result.count("log-tokens");
     opts.logAst_ = result.count("log-ast");
     opts.logAssembly_ = result.count("log-assembly");
+
+    const std::string targetType = result["target-type"].as<std::string>();
+    if (targetType == "bin") {
+        opts.targetType_ = TargetType::EXECUTABLE;
+    } else if (targetType == "lib") {
+        opts.targetType_ = TargetType::LIBRARY;
+    } else {
+        print_error(std::format("Unknown target type: '{}'", targetType));
+        std::cout << '\n' << options.help() << '\n';
+        std::exit(EXIT_FAILURE);
+    }
 
     if (result.count("debug")) {
         opts.logCode_ = opts.logTokens_ = opts.logAst_ = opts.logAssembly_ = true;

--- a/src/generation/generator.cpp
+++ b/src/generation/generator.cpp
@@ -90,7 +90,7 @@ void Generator::move_boolean_lit_to_rax(const AST::BooleanLiteral& booleanLit) {
 }
 
 std::string Generator::function_name_with_prefix(const std::string& name) const {
-    return "__" + name;  // Prefix with "fn_" to avoid conflicts with NASM keywords
+    return "__" + name;  // Prefix with "__" to avoid conflicts with NASM keywords
 }
 
 void Generator::generate_function_call(  // NOLINT(*-no-recursion)

--- a/src/generation/generator.cpp
+++ b/src/generation/generator.cpp
@@ -10,18 +10,22 @@
 std::stringstream Generator::generate() {
     // Declare external functions
     for (const auto& externalFuncDecl : program_.externalFunctions_) {
-        output_ << "extern " << function_name_with_prefix(externalFuncDecl->identifier_->name_) << "\n";
+        output_ << "extern " << function_name_with_prefix(externalFuncDecl->identifier_->name_)
+                << "\n";
     }
 
     output_ << "\n";
 
     // Write the header
     output_ << "section .text\n";
-    output_ << "global _start\n";
-    output_ << "_start:\n";
-    output_ << "    push rbp\n";
-    output_ << "    mov rbp, rsp\n\n";
-    output_ << "    call " << function_name_with_prefix("main") << "\n";
+
+    if (targetType_ == TargetType::EXECUTABLE) {
+        output_ << "global _start\n";
+        output_ << "_start:\n";
+        output_ << "    push rbp\n";
+        output_ << "    mov rbp, rsp\n\n";
+        output_ << "    call " << function_name_with_prefix("main") << "\n";
+    }
 
     generate_exit("0");
 

--- a/src/generation/generator.cpp
+++ b/src/generation/generator.cpp
@@ -25,9 +25,8 @@ std::stringstream Generator::generate() {
         output_ << "    push rbp\n";
         output_ << "    mov rbp, rsp\n\n";
         output_ << "    call " << function_name_with_prefix("main") << "\n";
+        generate_exit("0");
     }
-
-    generate_exit("0");
 
     for (const auto& funcDef : program_.functions_) {
         generate_function_definition(*funcDef);
@@ -332,6 +331,11 @@ void Generator::generate_stmt(const AST::Statement& stmt) {  // NOLINT(*-no-recu
 
 void Generator::generate_function_definition(const AST::FunctionDefinition& funcDef) {
     output_ << "\n";
+
+    if (funcDef.isExported_) {
+        output_ << "global " << function_name_with_prefix(funcDef.identifier_->name_) << "\n";
+    }
+
     output_ << function_name_with_prefix(funcDef.identifier_->name_)
             << ":\n";  // Prefix with "fn_" to avoid conflicts with NASM keywords
 

--- a/src/generation/generator.cpp
+++ b/src/generation/generator.cpp
@@ -91,7 +91,7 @@ void Generator::move_boolean_lit_to_rax(const AST::BooleanLiteral& booleanLit) {
 }
 
 std::string Generator::function_name_with_prefix(const std::string& name) const {
-    return "func_" + name;  // Prefix with "fn_" to avoid conflicts with NASM keywords
+    return "__" + name;  // Prefix with "fn_" to avoid conflicts with NASM keywords
 }
 
 void Generator::generate_function_call(  // NOLINT(*-no-recursion)

--- a/src/lexing/lexer.cpp
+++ b/src/lexing/lexer.cpp
@@ -36,6 +36,7 @@ std::optional<TokenKind> Lexer::get_keyword_kind() const {
     if (buffer_ == "continue") return TokenKind::CONTINUE;
     if (buffer_ == "fn") return TokenKind::FN;
     if (buffer_ == "extern") return TokenKind::EXTERN;
+    if (buffer_ == "export") return TokenKind::EXPORT;
     if (buffer_ == "return") return TokenKind::RETURN;
     if (buffer_ == "exit") return TokenKind::EXIT;
 

--- a/src/lexing/token_kind.cpp
+++ b/src/lexing/token_kind.cpp
@@ -1,95 +1,10 @@
 #include "lexing/token_kind.hpp"
 
-#include <stdexcept>
 #include <string>
 
+#include "magic_enum.hpp"
+
 std::string token_kind_to_string(const TokenKind kind) {
-    switch (kind) {
-        case TokenKind::IDENTIFIER:
-            return "IDENTIFIER";
-        case TokenKind::NUMBER_LITERAL:
-            return "NUMBER_LITERAL";
-
-        case TokenKind::PLUS:
-            return "PLUS";
-        case TokenKind::MINUS:
-            return "MINUS";
-        case TokenKind::STAR:
-            return "STAR";
-        case TokenKind::SLASH:
-            return "SLASH";
-        case TokenKind::BANG:
-            return "BANG";
-        case TokenKind::EQUAL:
-            return "EQUAL";
-        case TokenKind::EQUAL_EQUAL:
-            return "EQUAL_EQUAL";
-        case TokenKind::BANG_EQUAL:
-            return "BANG_EQUAL";
-        case TokenKind::LESS_THAN:
-            return "LESS_THAN";
-        case TokenKind::LESS_THAN_EQUAL:
-            return "LESS_THAN_EQUAL";
-        case TokenKind::GREATER_THAN:
-            return "GREATER_THAN";
-        case TokenKind::GREATER_THAN_EQUAL:
-            return "GREATER_THAN_EQUAL";
-
-        case TokenKind::LEFT_PAREN:
-            return "LEFT_PAREN";
-        case TokenKind::RIGHT_PAREN:
-            return "RIGHT_PAREN";
-        case TokenKind::LEFT_BRACE:
-            return "LEFT_BRACE";
-        case TokenKind::RIGHT_BRACE:
-            return "RIGHT_BRACE";
-        case TokenKind::COLON:
-            return "COLON";
-        case TokenKind::SEMICOLON:
-            return "SEMICOLON";
-        case TokenKind::COMMA:
-            return "COMMA";
-        case TokenKind::RIGHT_ARROW:
-            return "RIGHT_ARROW";
-
-        case TokenKind::TRUE:
-            return "TRUE";
-        case TokenKind::FALSE:
-            return "FALSE";
-        case TokenKind::CONST:
-            return "CONST";
-        case TokenKind::INT:
-            return "INT";
-        case TokenKind::BOOL:
-            return "BOOL";
-        case TokenKind::LET:
-            return "LET";
-        case TokenKind::MUT:
-            return "MUT";
-        case TokenKind::IF:
-            return "IF";
-        case TokenKind::ELIF:
-            return "ELIF";
-        case TokenKind::ELSE:
-            return "ELSE";
-        case TokenKind::WHILE:
-            return "WHILE";
-        case TokenKind::BREAK:
-            return "BREAK";
-        case TokenKind::CONTINUE:
-            return "CONTINUE";
-        case TokenKind::FN:
-            return "FN";
-        case TokenKind::EXTERN:
-            return "EXTERN";
-        case TokenKind::RETURN:
-            return "RETURN";
-        case TokenKind::EXIT:
-            return "EXIT";
-
-        case TokenKind::EOF_:
-            return "EOF_";
-        default:
-            throw std::invalid_argument("Invalid token kind passed to token_kind_to_string");
-    }
+    const auto name = magic_enum::enum_name(kind);
+    return std::string{name};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,23 +28,23 @@ void show_step(std::string_view message) {
 template <typename F>
 decltype(auto) timed(const std::string_view message, bool showStep, F&& f) {
     show_step(message);
+
     const auto start = Clock::now();
+
+    auto printElapsedTime = [&] {
+        if (showStep) {
+            const auto ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
+            std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
+        }
+    };
 
     if constexpr (std::is_void_v<std::invoke_result_t<F>>) {
         std::forward<F>(f)();
-        if (showStep) {
-            const auto ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
-            std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
-        }
+        printElapsedTime();
     } else {
-        auto result = std::forward<F>(f)();
-        if (showStep) {
-            const auto ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
-            std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
-        }
-
+        decltype(auto) result = std::forward<F>(f)();
+        printElapsedTime();
         return result;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,32 +26,37 @@ void show_step(std::string_view message) {
 }
 
 template <typename F>
-decltype(auto) timed(const std::string_view message, F&& f) {
+decltype(auto) timed(const std::string_view message, bool showStep, F&& f) {
     show_step(message);
     const auto start = Clock::now();
 
     if constexpr (std::is_void_v<std::invoke_result_t<F>>) {
         std::forward<F>(f)();
-        const auto ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
-        std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
+        if (showStep) {
+            const auto ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
+            std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
+        }
     } else {
         auto result = std::forward<F>(f)();
-        const auto ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
-        std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
+        if (showStep) {
+            const auto ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
+            std::cout << "\r\33[2K\033[1;32m✓\033[0m " << message << " (" << ms << " ms)\n";
+        }
+
         return result;
     }
 }
 
-void run_or_die(const char* cmd) {
-    if (std::system(cmd) != 0) {
+void run_or_die(const std::string& cmd) {
+    if (std::system(cmd.c_str()) != 0) {
         print_error(std::format("Command '{}' failed", cmd));
         std::exit(EXIT_FAILURE);
     }
 }
 
-void compile_file(const CompilerOptions opts) {
+void compile_file(const CompilerOptions& opts, bool verbose = true) {
     const std::ifstream source(opts.sourceFilename_);
     if (!source) {
         print_error(std::format("Could not open file '{}'", opts.sourceFilename_));
@@ -64,24 +69,32 @@ void compile_file(const CompilerOptions opts) {
 
     if (opts.logCode_) std::cout << code << '\n';
 
-    const auto tokens = timed("Lexing", [&] { return Lexer(code).tokenize(); });
+    const auto tokens = timed("Lexing", verbose, [&] { return Lexer(code).tokenize(); });
     if (opts.logTokens_) {
         for (const auto& token : tokens)
             std::cout << token_kind_to_string(token.kind()) << ": `" << token.lexeme() << "`\n";
     }
 
-    const auto ast = timed("Parsing", [&] { return Parser(tokens).parse(); });
+    const auto ast = timed("Parsing", verbose, [&] { return Parser(tokens).parse(); });
     if (opts.logAst_) AST::log_ast(*ast);
 
-    timed("Semantic analysis", [&] { SemanticAnalyser(*ast, opts.targetType_).analyse(); });
+    timed("Semantic analysis", verbose,
+          [&] { SemanticAnalyser(*ast, opts.targetType_).analyse(); });
 
-    const auto assembly = timed("Code generation", [&] { return Generator(*ast).generate(); });
+    const auto assembly = timed("Code generation", verbose,
+                                [&] { return Generator(*ast, opts.targetType_).generate(); });
     if (opts.logAssembly_) std::cout << assembly.str();
 
-    run_or_die("rm -rf neutro && mkdir neutro");
+    std::string outFilename;
+    if (opts.targetType_ == TargetType::EXECUTABLE) {
+        outFilename = "neutro/out.asm";
+    } else {
+        outFilename =
+            "neutro/" + std::filesystem::path(opts.sourceFilename_).stem().string() + ".asm";
+    }
 
     {
-        std::ofstream out("neutro/out.asm");
+        std::ofstream out(outFilename);
         if (!out) {
             print_error("Could not open output file");
             exit(EXIT_FAILURE);
@@ -89,7 +102,7 @@ void compile_file(const CompilerOptions opts) {
         out << assembly.str();
     }
 
-    timed("Assembling", [] { run_or_die("nasm -felf64 neutro/out.asm"); });
+    timed("Assembling", verbose, [&] { run_or_die(std::format("nasm -felf64 {}", outFilename)); });
 }
 
 }  // namespace
@@ -99,22 +112,35 @@ int main(const int argc, char* argv[]) {
 
     const auto startTime = Clock::now();
 
+    run_or_die("rm -rf neutro && mkdir neutro");
+
     compile_file(opts);
 
     const std::filesystem::path runtimePath = std::filesystem::path(PROJECT_ROOT_DIR) / "runtime";
-    timed("Assembling runtime", [&] {
-        for (const auto& entry : std::filesystem::directory_iterator(runtimePath)) {
-            if (entry.path().extension() == ".asm") {
-                const std::string src = entry.path().string();
-                const std::string name =
-                    entry.path().stem().string();  // filename without extension
-                const std::string out = "neutro/" + name + ".o";
-                run_or_die(("nasm -felf64 " + src + " -o " + out).c_str());
+
+    timed("Building runtime", true, [&] {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(runtimePath)) {
+            if (!entry.is_regular_file()) continue;
+
+            const std::string extension = entry.path().extension();
+            const std::string src = entry.path().string();
+            if (extension == ".nt") {
+                compile_file(CompilerOptions{
+                    .logCode_ = opts.logCode_,
+                    .logTokens_ = opts.logTokens_,
+                    .logAst_ = opts.logAst_,
+                    .logAssembly_ = opts.logAssembly_,
+                    .sourceFilename_ = src,
+                    .targetType_ = TargetType::LIBRARY,
+                }, false);
+            } else if (extension == ".asm") {
+                const std::string obj = "neutro/" + entry.path().stem().string() + ".o";
+                run_or_die(std::format("nasm -felf64 {} -o {}", src, obj));
             }
         }
     });
 
-    timed("Linking", [] { run_or_die("ld -o neutro/out neutro/*.o"); });
+    timed("Linking", true, [] { run_or_die("ld -o neutro/out neutro/*.o"); });
 
     std::cout
         << "== Compiled successfully in "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,17 +124,26 @@ int main(const int argc, char* argv[]) {
 
             const std::string extension = entry.path().extension();
             const std::string src = entry.path().string();
+
             if (extension == ".nt") {
-                compile_file(CompilerOptions{
-                    .logCode_ = opts.logCode_,
-                    .logTokens_ = opts.logTokens_,
-                    .logAst_ = opts.logAst_,
-                    .logAssembly_ = opts.logAssembly_,
-                    .sourceFilename_ = src,
-                    .targetType_ = TargetType::LIBRARY,
-                }, false);
+                compile_file(
+                    CompilerOptions{
+                        .logCode_ = opts.logCode_,
+                        .logTokens_ = opts.logTokens_,
+                        .logAst_ = opts.logAst_,
+                        .logAssembly_ = opts.logAssembly_,
+                        .sourceFilename_ = src,
+                        .targetType_ = TargetType::LIBRARY,
+                    },
+                    false);
             } else if (extension == ".asm") {
                 const std::string obj = "neutro/" + entry.path().stem().string() + ".o";
+
+                if (std::filesystem::exists(obj)) {
+                    print_error(std::format("Duplicate object name would overwrite `{}`", obj));
+                    exit(EXIT_FAILURE);
+                }
+
                 run_or_die(std::format("nasm -felf64 {} -o {}", src, obj));
             }
         }

--- a/src/semantic-analysis/semantic_analyser.cpp
+++ b/src/semantic-analysis/semantic_analyser.cpp
@@ -21,12 +21,18 @@ void SemanticAnalyser::analyse() {
     }
 
     const auto mainIt = functionsTable_.find("main");
-    if (mainIt == functionsTable_.end() || mainIt->second.kind_ != SymbolKind::FUNCTION) {
-        abort("No `main` function found");
-    } else if (mainIt->second.type_.raw() != RawType::VOID) {
-        abort("`main` function must return `void`");
-    } else if (mainIt->second.parameters_.size() != 0) {
-        abort("`main` function must not take any parameters");
+    if (targetType_ == TargetType::EXECUTABLE) {
+        if (mainIt == functionsTable_.end() || mainIt->second.kind_ != SymbolKind::FUNCTION) {
+            abort("No `main` function found");
+        } else if (mainIt->second.type_.raw() != RawType::VOID) {
+            abort("`main` function must return `void`");
+        } else if (mainIt->second.parameters_.size() != 0) {
+            abort("`main` function must not take any parameters");
+        }
+    } else {
+        if (mainIt != functionsTable_.end()) {
+            abort("`main` function is not allowed in a library target");
+        }
     }
 }
 
@@ -79,8 +85,7 @@ SymbolInfo& SemanticAnalyser::declare_symbol(const std::string& name, const Symb
                                 std::to_string(static_cast<int>(kind)));
 }
 
-SymbolInfo& SemanticAnalyser::handle_constant_definition(const std::string& name,
-                                                          const Type type) {
+SymbolInfo& SemanticAnalyser::handle_constant_definition(const std::string& name, const Type type) {
     return declare_symbol(name, SymbolKind::CONSTANT, false, type, false, {});
 }
 
@@ -237,8 +242,7 @@ void SemanticAnalyser::analyse_expression(const AST::Expression& expr, const Typ
     }
 }
 
-void SemanticAnalyser::analyse_variable_definition(
-    const AST::VariableDefinition& declaration) {
+void SemanticAnalyser::analyse_variable_definition(const AST::VariableDefinition& declaration) {
     const std::string& name = declaration.identifier_->name_;
     const Type variableType = get_expression_type(*declaration.value_);
 

--- a/src/semantic-analysis/semantic_analyser.cpp
+++ b/src/semantic-analysis/semantic_analyser.cpp
@@ -23,7 +23,7 @@ void SemanticAnalyser::analyse() {
     const auto mainIt = functionsTable_.find("main");
     if (targetType_ == TargetType::EXECUTABLE) {
         if (mainIt == functionsTable_.end() || mainIt->second.kind_ != SymbolKind::FUNCTION) {
-            abort("No `main` function found");
+            abort("No `main` function found in executable target");
         } else if (mainIt->second.type_.raw() != RawType::VOID) {
             abort("`main` function must return `void`");
         } else if (mainIt->second.parameters_.size() != 0) {

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+set -euo pipefail
+
 ./cmake-build.sh
 ./build/tests

--- a/tests/cli_tests.cpp
+++ b/tests/cli_tests.cpp
@@ -8,8 +8,9 @@
 const std::string projectRoot = PROJECT_ROOT_DIR;
 const std::string neutroniumPath = projectRoot + "/build/neutronium";
 
-// Same helper as before
-static int run_and_capture(const std::string& cmd, std::string& out) {
+namespace {
+
+int run_and_capture(const std::string& cmd, std::string& out) {
     FILE* pipe = popen((cmd + " 2>&1").c_str(), "r");
     if (!pipe) return -1;
 
@@ -19,35 +20,81 @@ static int run_and_capture(const std::string& cmd, std::string& out) {
         out += buffer.data();
     }
 
-    int rc = pclose(pipe);
+    const int rc = pclose(pipe);
     if (WIFEXITED(rc)) return WEXITSTATUS(rc);
     return -1;
 }
 
+}  // namespace
+
 TEST(CliErrorTest, MissingSourceFilepath) {
     std::string output;
-    int status = run_and_capture(neutroniumPath, output);
+    const int status = run_and_capture(neutroniumPath, output);
     EXPECT_NE(status, 0);
     EXPECT_TRUE(output.contains("Missing input file")) << output;
 }
 
 TEST(CliErrorTest, InvalidSourceFilepath) {
     std::string output;
-    int status = run_and_capture(neutroniumPath + " nonexistent_file.nt", output);
+    const int status = run_and_capture(neutroniumPath + " nonexistent_file.nt", output);
     EXPECT_NE(status, 0);
     EXPECT_TRUE(output.contains("Error:")) << output;
 }
 
+TEST(CLITargetTest, LibraryTarget) {
+    const std::string tempFile = projectRoot + "/temp_test.nt";
+    {
+        std::ofstream out(tempFile);
+        out << "fn abc(): { exit 0; }\n";  // No main function is valid
+    }
+
+    std::string output;
+    int status = run_and_capture(neutroniumPath + " --target-type=library " + tempFile, output);
+    EXPECT_TRUE(status == 0 || output.contains("Assembling"))
+        << output;  // Ensure it compiles successfully
+
+    {
+        std::ofstream out(tempFile);
+        out << "fn main(): { exit 0; }\n";  // Adding main function should fail
+    }
+
+    status = run_and_capture(neutroniumPath + " --target-type=library " + tempFile, output);
+    EXPECT_NE(status, 0);
+    EXPECT_TRUE(output.contains("main") && output.contains("library target")) << output;
+}
+
+TEST(CLITargetTest, ExecutableTarget) {
+    const std::string tempFile = projectRoot + "/temp_test.nt";
+    {
+        std::ofstream out(tempFile);
+        out << "fn abc(): { exit 0; }\n";  // No main function should fail
+    }
+
+    std::string output;
+    int status = run_and_capture(neutroniumPath + " --target-type=executable " + tempFile, output);
+    EXPECT_NE(status, 0);
+    EXPECT_TRUE(output.contains("main") && output.contains("executable target")) << output;
+
+    {
+        std::ofstream out(tempFile);
+        out << "fn main(): { exit 0; }\n";  // Adding main function should succeed
+    }
+
+    status = run_and_capture(neutroniumPath + " --target-type=executable " + tempFile, output);
+    EXPECT_TRUE(status == 0 || output.contains("Assembling"))
+        << output;  // Ensure it compiles successfully
+}
+
 TEST(CliErrorTest, InvalidLogType) {
     std::string output;
-    int status = run_and_capture(neutroniumPath + " --log=invalid", output);
+    const int status = run_and_capture(neutroniumPath + " --log=invalid", output);
     EXPECT_NE(status, 0);
     EXPECT_TRUE(output.contains("Unknown log type")) << output;
 }
 
 TEST(CliNonErrorTest, HelpOption) {
     std::string output;
-    int status = run_and_capture(neutroniumPath + " --help", output);
+    const int status = run_and_capture(neutroniumPath + " --help", output);
     EXPECT_EQ(status, 0);
     EXPECT_TRUE(output.contains("Usage:")) << output;
 }
@@ -60,7 +107,7 @@ TEST(CliNonErrorTest, ValidMinimalSourceFile) {
     }
 
     std::string output;
-    int status = run_and_capture(neutroniumPath + " " + tempFile, output);
+    const int status = run_and_capture(neutroniumPath + " " + tempFile, output);
     EXPECT_EQ(status, 0) << output;
 
     std::remove(tempFile.c_str());
@@ -68,7 +115,7 @@ TEST(CliNonErrorTest, ValidMinimalSourceFile) {
 
 TEST(CliErrorTest, InvalidOption) {
     std::string output;
-    int status = run_and_capture(neutroniumPath + " --invalid-option", output);
+    const int status = run_and_capture(neutroniumPath + " --invalid-option", output);
     EXPECT_NE(status, 0);
     EXPECT_TRUE(output.contains("Error") && output.contains("does not exist")) << output;
 }
@@ -82,7 +129,7 @@ TEST(CliNonErrorTest, LogArguments) {
 
     std::string output;
 
-    std::string baseCompileCommand = neutroniumPath + " " + tempFile;
+    const std::string baseCompileCommand = neutroniumPath + " " + tempFile;
 
     int status = run_and_capture(baseCompileCommand + " --log-code", output);
     EXPECT_EQ(status, 0) << output;

--- a/tests/cli_tests.cpp
+++ b/tests/cli_tests.cpp
@@ -41,6 +41,13 @@ TEST(CliErrorTest, InvalidSourceFilepath) {
     EXPECT_TRUE(output.contains("Error:")) << output;
 }
 
+TEST(CLIErrorTest, InvalidTargetType) {
+    std::string output;
+    const int status = run_and_capture(neutroniumPath + " --target-type=invalid", output);
+    EXPECT_NE(status, 0);
+    EXPECT_TRUE(output.contains("Unknown target type")) << output;
+}
+
 TEST(CLITargetTest, LibraryTarget) {
     const std::string tempFile = projectRoot + "/temp_test.nt";
     {

--- a/tests/execution_test.cpp
+++ b/tests/execution_test.cpp
@@ -149,6 +149,14 @@ TEST_F(NeutroniumTester, StandardLibrary) {
         extern fn print_c(char: int);
         extern fn print_num(num: int);
 
+        extern fn mod(a: int, b: int) -> int;
+
+        fn print_mod(a: int, b: int): {
+            let result = mod(a, b);
+            print_num(result);
+            print_c(10);
+        }
+
         fn main(): {
             print_c(72);
             print_c(101);
@@ -168,11 +176,13 @@ TEST_F(NeutroniumTester, StandardLibrary) {
             print_num(42);
             print_c(10);
             print_c(10);
+
+            print_mod(654, 10);  # should print 4
         }
     )";
     const auto result = run_with_output(code);
     EXPECT_EQ(result.exit, 0);
-    EXPECT_EQ(result.output, "Hello, World!\n42\n\n");
+    EXPECT_EQ(result.output, "Hello, World!\n42\n\n4\n");
 }
 
 TEST_F(NeutroniumTester, FunctionReturnValues) {


### PR DESCRIPTION
New `export` syntax and two target types: executable or library. This allows the standard library to be written in Neutronium.