### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Thibault-Monnier/neutronium/security/code-scanning/3](https://github.com/Thibault-Monnier/neutronium/security/code-scanning/3)

To fix the problem, we need to add a `permissions` block to the workflow file `.github/workflows/test.yml`. Since the workflow only checks out code and runs tests, the minimal permission needed is `contents: read`. Add the `permissions:` block at the root of the workflow, right after the workflow name and before the `on:` or `jobs:` keys, so that all jobs within the workflow will inherit these permissions by default. The change only requires a single addition and does not impact existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
