### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build all targets
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Thibault-Monnier/neutronium/security/code-scanning/2](https://github.com/Thibault-Monnier/neutronium/security/code-scanning/2)

To fix this problem, the workflow should explicitly declare a `permissions` key at either the top level (applies to all jobs) or specifically for the `build_check` job. The simplest and best fix here is to add `permissions: contents: read` at the top level, right after the `name` and before `on`, since nothing in the job requires more than reading repository contents. This makes the workflow secure by applying the principle of least privilege with the least disruption to existing code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
