### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: Test Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Thibault-Monnier/neutronium/security/code-scanning/1](https://github.com/Thibault-Monnier/neutronium/security/code-scanning/1)

To fix this issue, we need to add a `permissions` block to the workflow so that the permissions granted to the GITHUB_TOKEN are minimized. Since the workflow only needs to check out code and upload coverage to an external service (Codecov), the minimum required permission is typically `contents: read`. Unless you know that write access to other repository resources (issues, pull-requests, etc.) is required (which it is not for this workflow), you should add `permissions: contents: read` at either workflow root (before `jobs:`) or at the job level (under `coverage:`). Adding at the root will ensure all jobs in the workflow (should others be added) inherit minimal permissions, which is recommended.

Therefore, edit `.github/workflows/coverage.yml` by adding the following block after the workflow name and before `jobs:`:

```yaml
permissions:
  contents: read
```

No special imports, no method definitions, and no changes elsewhere are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
