### PR TITLE
Accumulate parsing errors

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -51,7 +51,8 @@ break-statement ::= 'break' ';'
 
 continue-statement ::= 'continue' ';'
 
-return-statement ::= 'return' expression ';'
+return-statement ::= 'return' ';'
+                   | 'return' expression ';'
 
 exit-statement ::= 'exit' expression ';'
 

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -129,7 +129,6 @@ void compileFile(const CompilerOptions& opts, SourceManager& sourceManager, bool
 }  // namespace
 
 int main(const int argc, const char** argv) {
-
     const CompilerOptions opts = parse_cli(argc, argv);
     const auto startTime = Clock::now();
 

--- a/src/parse/Parser.cpp
+++ b/src/parse/Parser.cpp
@@ -16,8 +16,7 @@
         *_tok_;                                 \
     })
 #else
-#define EXPECT_OR_RETURN_NULLPTR(tokenKind) \
-    (static_assert(false, "EXPECT_OR_RETURN_NULLPTR is not supported by your compiler."), nullptr)
+#error "EXPECT_OR_RETURN_NULLPTR is not supported by your compiler."
 #endif
 
 std::unique_ptr<AST::Program> Parser::parse() {
@@ -79,7 +78,7 @@ std::optional<std::vector<std::unique_ptr<T>>> Parser::parseCommaSeparatedList(
     std::vector<std::unique_ptr<T>> elements;
     while (peek().kind() != endDelimiter) {
         auto elem = parseElement();
-        if (!elem) return {};
+        if (!elem) return std::nullopt;
         elements.push_back(std::move(elem));
         if (!advanceIf(TokenKind::COMMA)) break;
     }
@@ -633,8 +632,8 @@ std::unique_ptr<AST::Program> Parser::parseProgram() {
                 program->appendFunction(std::move(functionDefinition));
                 continue;
             }
-        } else if (!isRecoveringFromError) {  // If we are already recovering from an error, avoid
-                                              // spamming errors
+        } else if (!isRecoveringFromError) { /* If we are already recovering from an error, avoid
+                                              spamming errors */
             const std::string errorMessage =
                 std::format("Invalid token -> expected function definition, got {}",
                             tokenKindToString(peek().kind()));

--- a/src/parse/Parser.cpp
+++ b/src/parse/Parser.cpp
@@ -4,19 +4,42 @@
 #include <format>
 #include <functional>
 #include <memory>
-#include <print>
 #include <string>
 
 #include "lex/Token.hpp"
 
-std::unique_ptr<AST::Program> Parser::parse() { return parseProgram(); }
+#if defined(__GNUC__) || defined(__clang__)
+#define EXPECT_OR_RETURN_NULLPTR(tokenKind)     \
+    __extension__({                             \
+        const Token* _tok_ = expect(tokenKind); \
+        if (!_tok_) return nullptr;             \
+        *_tok_;                                 \
+    })
+#else
+#define EXPECT_OR_RETURN_NULLPTR(tokenKind) \
+    (static_assert(false, "EXPECT_OR_RETURN_NULLPTR is not supported by your compiler."), nullptr)
+#endif
 
-void Parser::abort(const std::string& errorMessage) const {
+std::unique_ptr<AST::Program> Parser::parse() {
+    auto ast = parseProgram();
+
+    if (diagnosticsEngine_.hasErrors()) {
+        diagnosticsEngine_.emitErrors();
+        exit(EXIT_FAILURE);
+    }
+
+    return ast;
+}
+
+void Parser::emitError(const std::string& errorMessage) const {
     const Token& token = peek();
     diagnosticsEngine_.reportError(errorMessage, token.byteOffsetStart(), token.byteOffsetEnd());
+}
 
-    diagnosticsEngine_.emitErrors();
-    exit(EXIT_FAILURE);
+template <typename T>
+std::unique_ptr<T> Parser::emitError(const std::string& errorMessage) const {
+    emitError(errorMessage);
+    return nullptr;
 }
 
 const Token& Parser::peek(const int amount) const { return tokens_.at(currentIndex_ + amount); }
@@ -36,31 +59,34 @@ bool Parser::advanceIf(const TokenKind expected) {
     return matches;
 }
 
-const Token& Parser::expect(const TokenKind expected) {
+const Token* Parser::expect(const TokenKind expected) {
     const Token& token = peek();
 
     if (token.kind() != expected) {
         const std::string errorMessage =
             std::format("Invalid token -> expected {}, got {}", tokenKindToString(expected),
                         tokenKindToString(token.kind()));
-        abort(errorMessage);
+        emitError(errorMessage);
+        return nullptr;
     }
 
-    return advance();
+    return &advance();
 }
 
 template <typename T>
-std::vector<std::unique_ptr<T>> Parser::parseCommaSeparatedList(
+std::optional<std::vector<std::unique_ptr<T>>> Parser::parseCommaSeparatedList(
     const TokenKind endDelimiter, const std::function<std::unique_ptr<T>()>& parseElement) {
     std::vector<std::unique_ptr<T>> elements;
     while (peek().kind() != endDelimiter) {
-        elements.push_back(parseElement());
+        auto elem = parseElement();
+        if (!elem) return {};
+        elements.push_back(std::move(elem));
         if (!advanceIf(TokenKind::COMMA)) break;
     }
     return elements;
 }
 
-std::vector<std::unique_ptr<AST::Expression>> Parser::parseExpressionList(
+std::optional<std::vector<std::unique_ptr<AST::Expression>>> Parser::parseExpressionList(
     const TokenKind endDelimiter) {
     return parseCommaSeparatedList<AST::Expression>(endDelimiter,
                                                     [this]() { return parseExpression(); });
@@ -85,64 +111,84 @@ std::optional<Type> Parser::tryParsePrimitiveType(const TokenKind tokenKind) {
     }
 }
 
-Type Parser::parseTypeSpecifier() {
+std::unique_ptr<Type> Parser::parseTypeSpecifier() {
     const TokenKind tokenKind = peek().kind();
 
     if (auto type = tryParsePrimitiveType(tokenKind)) {
-        expect(tokenKind);
-        return *type;
+        advance();
+        return std::make_unique<Type>(*type);
     }
 
     if (advanceIf(TokenKind::LEFT_BRACKET)) {
-        const TypeID elementTypeID = typeManager_.createType(parseTypeSpecifier());
-        expect(TokenKind::SEMICOLON);
-        const std::size_t arrayLength = parseNumberLiteral()->value_;
-        expect(TokenKind::RIGHT_BRACKET);
-        return Type{elementTypeID, arrayLength};
+        auto elementType = parseTypeSpecifier();
+        if (!elementType) return nullptr;
+
+        const TypeID elementTypeID = typeManager_.createType(*elementType);
+        EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
+
+        auto arrayLength = parseNumberLiteral();
+        if (!arrayLength) return nullptr;
+
+        EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACKET);
+        return std::make_unique<Type>(elementTypeID, arrayLength->value_);
     }
 
     const std::string errorMessage = std::format("Invalid token -> expected type specifier, got {}",
                                                  tokenKindToString(tokenKind));
-    abort(errorMessage);
+    return emitError<Type>(errorMessage);
+}
+
+std::optional<Type> Parser::maybeParseTypeAnnotation(const TokenKind typeAnnotationIndicator,
+                                                     Type defaultType) {
+    if (advanceIf(typeAnnotationIndicator)) {
+        auto parsedType = parseTypeSpecifier();
+        if (!parsedType) return std::nullopt;
+        return *parsedType;
+    }
+    return defaultType;
 }
 
 std::unique_ptr<AST::Identifier> Parser::parseIdentifier() {
-    const Token& ident = expect(TokenKind::IDENTIFIER);
+    const Token& ident = EXPECT_OR_RETURN_NULLPTR(TokenKind::IDENTIFIER);
     return std::make_unique<AST::Identifier>(ident.lexeme(), ident.byteOffsetStart(),
                                              ident.byteOffsetEnd(), generateAnyType());
 }
 
 std::unique_ptr<AST::NumberLiteral> Parser::parseNumberLiteral() {
-    const Token& token = expect(TokenKind::NUMBER_LITERAL);
+    const Token& token = EXPECT_OR_RETURN_NULLPTR(TokenKind::NUMBER_LITERAL);
     return std::make_unique<AST::NumberLiteral>(std::stoll(token.lexeme()), token.byteOffsetStart(),
                                                 token.byteOffsetEnd(), generateAnyType());
 }
 
 std::unique_ptr<AST::ArrayLiteral> Parser::parseArrayLiteral() {
-    const Token& lBracket = expect(TokenKind::LEFT_BRACKET);
+    const Token& lBracket = EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_BRACKET);
     auto elements = parseExpressionList(TokenKind::RIGHT_BRACKET);
-    const Token& rBracket = expect(TokenKind::RIGHT_BRACKET);
+    if (!elements) return nullptr;
+    const Token& rBracket = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACKET);
 
-    return std::make_unique<AST::ArrayLiteral>(std::move(elements), lBracket.byteOffsetStart(),
-                                               rBracket.byteOffsetEnd(), generateAnyType());
+    return std::make_unique<AST::ArrayLiteral>(std::move(elements.value()),
+                                               lBracket.byteOffsetStart(), rBracket.byteOffsetEnd(),
+                                               generateAnyType());
 }
 
 std::unique_ptr<AST::FunctionCall> Parser::parseFunctionCall() {
     auto callee = parseIdentifier();
 
-    expect(TokenKind::LEFT_PAREN);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_PAREN);
     auto arguments = parseExpressionList(TokenKind::RIGHT_PAREN);
-    const Token& rParen = expect(TokenKind::RIGHT_PAREN);
+    if (!arguments) return nullptr;
+    const Token& rParen = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_PAREN);
 
-    return std::make_unique<AST::FunctionCall>(std::move(callee), std::move(arguments),
+    return std::make_unique<AST::FunctionCall>(std::move(callee), std::move(arguments.value()),
                                                callee->sourceStartIndex(), rParen.byteOffsetEnd(),
                                                generateAnyType());
 }
 
 std::unique_ptr<AST::ArrayAccess> Parser::parseArrayAccess(std::unique_ptr<AST::Expression> base) {
-    expect(TokenKind::LEFT_BRACKET);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_BRACKET);
     auto index = parseExpression();
-    const Token& rBracket = expect(TokenKind::RIGHT_BRACKET);
+    if (!index) return nullptr;
+    const Token& rBracket = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACKET);
 
     return std::make_unique<AST::ArrayAccess>(std::move(base), std::move(index),
                                               base->sourceStartIndex(), rBracket.byteOffsetEnd(),
@@ -174,9 +220,10 @@ std::unique_ptr<AST::Expression> Parser::parsePrimaryExpression() {
             return parseIdentifier();
 
         case TokenKind::LEFT_PAREN: {
-            expect(TokenKind::LEFT_PAREN);
+            EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_PAREN);
             auto inner = parseExpression();
-            expect(TokenKind::RIGHT_PAREN);
+            if (!inner) return nullptr;
+            EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_PAREN);
             return inner;
         }
 
@@ -184,18 +231,20 @@ std::unique_ptr<AST::Expression> Parser::parsePrimaryExpression() {
             const std::string errorMessage =
                 std::format("Invalid token at beginning of primary expression -> got {}",
                             tokenKindToString(token.kind()));
-            abort(errorMessage);
+            return emitError<AST::Expression>(errorMessage);
         }
     }
 }
 
 std::unique_ptr<AST::Expression> Parser::parsePostfixExpression() {
     auto postfixExpr = parsePrimaryExpression();
+    if (!postfixExpr) return nullptr;
 
     while (true) {
         const Token& token = peek();
         if (token.kind() == TokenKind::LEFT_BRACKET) {
             postfixExpr = parseArrayAccess(std::move(postfixExpr));
+            if (!postfixExpr) return nullptr;
         } else {
             break;
         }
@@ -210,8 +259,10 @@ std::unique_ptr<AST::Expression> Parser::parseUnaryExpression() {
     const AST::Operator op = AST::tokenKindToOperator(token.kind());
     if (op == AST::Operator::ADD || op == AST::Operator::SUBTRACT ||
         op == AST::Operator::LOGICAL_NOT) {
-        expect(token.kind());
+        advance();
         auto operand = parsePostfixExpression();
+        if (!operand) return nullptr;
+
         return std::make_unique<AST::UnaryExpression>(op, std::move(operand),
                                                       token.byteOffsetStart(),
                                                       operand->sourceEndIndex(), generateAnyType());
@@ -224,12 +275,16 @@ std::unique_ptr<AST::Expression> Parser::parseBinaryExpression(
     const std::function<std::unique_ptr<AST::Expression>()>& parseOperand,
     const std::initializer_list<AST::Operator> allowedOps, const bool allowMultiple) {
     auto left = parseOperand();
+    if (!left) return nullptr;
+
     while (true) {
         const AST::Operator op = AST::tokenKindToOperator(peek().kind());
         if (std::ranges::find(allowedOps, op) == allowedOps.end()) break;
 
         advance();
         auto right = parseOperand();
+        if (!right) return nullptr;
+
         left = std::make_unique<AST::BinaryExpression>(std::move(left), op, std::move(right),
                                                        left->sourceStartIndex(),
                                                        right->sourceEndIndex(), generateAnyType());
@@ -262,24 +317,30 @@ std::unique_ptr<AST::Expression> Parser::parseExpression() { return parseCompari
 
 std::unique_ptr<AST::ExpressionStatement> Parser::parseExpressionStatement() {
     auto expression = parseExpression();
-    const Token& semi = expect(TokenKind::SEMICOLON);
+    if (!expression) return nullptr;
+    const Token& semi = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return std::make_unique<AST::ExpressionStatement>(
         std::move(expression), expression->sourceStartIndex(), semi.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::VariableDefinition> Parser::parseVariableDefinition() {
-    const Token& let = expect(TokenKind::LET);
+    const Token& let = EXPECT_OR_RETURN_NULLPTR(TokenKind::LET);
 
     const bool isMutable = advanceIf(TokenKind::MUT);
 
     auto identifier = parseIdentifier();
+    if (!identifier) return nullptr;
 
-    const Type type = advanceIf(TokenKind::COLON) ? parseTypeSpecifier() : Type::anyFamilyType();
-    const TypeID typeID = typeManager_.createType(type);
+    auto parsedType = maybeParseTypeAnnotation(TokenKind::COLON, Type::anyFamilyType());
+    if (!parsedType) return nullptr;
 
-    expect(TokenKind::EQUAL);
+    const TypeID typeID = typeManager_.createType(*parsedType);
+
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::EQUAL);
     auto value = parseExpression();
-    const Token& semi = expect(TokenKind::SEMICOLON);
+    if (!value) return nullptr;
+
+    const Token& semi = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
 
     return std::make_unique<AST::VariableDefinition>(std::move(identifier), typeID, isMutable,
                                                      std::move(value), let.byteOffsetStart(),
@@ -288,12 +349,20 @@ std::unique_ptr<AST::VariableDefinition> Parser::parseVariableDefinition() {
 
 std::unique_ptr<AST::Assignment> Parser::parseAssignment() {
     auto left = parseExpression();
+    if (!left) return nullptr;
 
     const Token& operatorToken = advance();
     const AST::Operator op = AST::tokenKindToOperator(operatorToken.kind());
+    if (!AST::isAssignmentOperator(op)) {
+        const std::string errorMessage =
+            std::format("Invalid token -> expected assignment operator, got {}",
+                        tokenKindToString(operatorToken.kind()));
+        return emitError<AST::Assignment>(errorMessage);
+    }
 
     auto right = parseExpression();
-    const Token& semi = expect(TokenKind::SEMICOLON);
+    if (!right) return nullptr;
+    const Token& semi = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
 
     return std::make_unique<AST::Assignment>(std::move(left), op, std::move(right),
                                              left->sourceStartIndex(), semi.byteOffsetEnd());
@@ -309,20 +378,25 @@ std::unique_ptr<AST::IfStatement> Parser::constructIfStatement(
 
 std::unique_ptr<AST::BlockStatement> Parser::parseElseClause() {
     if (advanceIf(TokenKind::ELSE)) {
-        expect(TokenKind::COLON);
+        EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
         return parseBlockStatement();
     }
 
     // ELIF case
-    const Token& elifTok = expect(TokenKind::ELIF);
+    const Token& elifTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::ELIF);
 
     auto elifCondition = parseExpression();
-    expect(TokenKind::COLON);
+    if (!elifCondition) return nullptr;
+
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
+
     auto elifBody = parseBlockStatement();
+    if (!elifBody) return nullptr;
 
     std::unique_ptr<AST::BlockStatement> elseClause;
     if (peek().kind() == TokenKind::ELIF || peek().kind() == TokenKind::ELSE) {
         elseClause = parseElseClause();
+        if (!elseClause) return nullptr;
     }
 
     auto elifStmt = constructIfStatement(std::move(elifCondition), std::move(elifBody),
@@ -336,14 +410,20 @@ std::unique_ptr<AST::BlockStatement> Parser::parseElseClause() {
 }
 
 std::unique_ptr<AST::IfStatement> Parser::parseIfStatement() {
-    const Token& ifTok = expect(TokenKind::IF);
+    const Token& ifTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::IF);
+
     auto condition = parseExpression();
-    expect(TokenKind::COLON);
+    if (!condition) return nullptr;
+
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
+
     auto body = parseBlockStatement();
+    if (!body) return nullptr;
 
     std::unique_ptr<AST::BlockStatement> elseClause;
     if (peek().kind() == TokenKind::ELIF || peek().kind() == TokenKind::ELSE) {
         elseClause = parseElseClause();
+        if (!elseClause) return nullptr;
     }
 
     return constructIfStatement(std::move(condition), std::move(body), std::move(elseClause),
@@ -351,53 +431,76 @@ std::unique_ptr<AST::IfStatement> Parser::parseIfStatement() {
 }
 
 std::unique_ptr<AST::WhileStatement> Parser::parseWhileStatement() {
-    const Token& whileTok = expect(TokenKind::WHILE);
+    const Token& whileTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::WHILE);
+
     auto condition = parseExpression();
-    expect(TokenKind::COLON);
+    if (!condition) return nullptr;
+
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
+
     auto body = parseBlockStatement();
+    if (!body) return nullptr;
+
     return std::make_unique<AST::WhileStatement>(
         std::move(condition), std::move(body), whileTok.byteOffsetStart(), body->sourceEndIndex());
 }
 
 std::unique_ptr<AST::BreakStatement> Parser::parseBreakStatement() {
-    const Token& breakTok = expect(TokenKind::BREAK);
-    const Token& semiTok = expect(TokenKind::SEMICOLON);
+    const Token& breakTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::BREAK);
+    const Token& semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return std::make_unique<AST::BreakStatement>(breakTok.byteOffsetStart(),
                                                  semiTok.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::ContinueStatement> Parser::parseContinueStatement() {
-    const Token& continueTok = expect(TokenKind::CONTINUE);
-    const Token& semiTok = expect(TokenKind::SEMICOLON);
+    const Token& continueTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::CONTINUE);
+    const Token& semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return std::make_unique<AST::ContinueStatement>(continueTok.byteOffsetStart(),
                                                     semiTok.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::ReturnStatement> Parser::parseReturnStatement() {
-    const Token& returnTok = expect(TokenKind::RETURN);
-    auto returnValue = parseExpression();
-    const Token& semiTok = expect(TokenKind::SEMICOLON);
+    const Token& returnTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::RETURN);
+
+    std::unique_ptr<AST::Expression> returnValue;
+    if (peek().kind() != TokenKind::SEMICOLON) {
+        returnValue = parseExpression();
+        if (!returnValue) return nullptr;
+    }
+
+    const Token& semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
+
     return std::make_unique<AST::ReturnStatement>(
         std::move(returnValue), returnTok.byteOffsetStart(), semiTok.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::ExitStatement> Parser::parseExitStatement() {
-    const Token& exitTok = expect(TokenKind::EXIT);
+    const Token& exitTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::EXIT);
     auto exitCode = parseExpression();
-    const Token& semiTok = expect(TokenKind::SEMICOLON);
+    if (!exitCode) return nullptr;
+    const Token& semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return std::make_unique<AST::ExitStatement>(std::move(exitCode), exitTok.byteOffsetStart(),
                                                 semiTok.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::BlockStatement> Parser::parseBlockStatement() {
-    const Token& lBrace = expect(TokenKind::LEFT_BRACE);
+    const Token& lBrace = EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_BRACE);
 
     std::vector<std::unique_ptr<AST::Statement>> statements;
-    while (peek().kind() != TokenKind::RIGHT_BRACE) {
-        statements.push_back(parseStatement());
+    while (peek().kind() != TokenKind::EOF_ && peek().kind() != TokenKind::RIGHT_BRACE) {
+        if (auto stmt = parseStatement()) {
+            statements.push_back(std::move(stmt));
+        } else {
+            // Error recovery: skip to the next semicolon or right brace.
+            while (peek().kind() != TokenKind::SEMICOLON &&
+                   peek().kind() != TokenKind::RIGHT_BRACE && peek().kind() != TokenKind::EOF_) {
+                advance();
+            }
+            advanceIf(TokenKind::SEMICOLON);
+        }
     }
 
-    const Token& rBrace = expect(TokenKind::RIGHT_BRACE);
+    const Token& rBrace = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACE);
 
     return std::make_unique<AST::BlockStatement>(std::move(statements), lBrace.byteOffsetStart(),
                                                  rBrace.byteOffsetEnd());
@@ -434,42 +537,48 @@ std::unique_ptr<AST::VariableDefinition> Parser::parseFunctionParameter() {
     const bool isMutable = advanceIf(TokenKind::MUT);
 
     auto identifier = parseIdentifier();
+    if (!identifier) return nullptr;
 
-    expect(TokenKind::COLON);
-    const Type type = parseTypeSpecifier();
-    const TypeID typeID = typeManager_.createType(type);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
+
+    auto parsedType = parseTypeSpecifier();
+    if (!parsedType) return nullptr;
+    const TypeID typeID = typeManager_.createType(*parsedType);
 
     return std::make_unique<AST::VariableDefinition>(
         std::move(identifier), typeID, isMutable, sourceStartIndex, identifier->sourceEndIndex());
 }
 
-ParsedFunctionSignature Parser::parseFunctionSignature() {
+std::unique_ptr<ParsedFunctionSignature> Parser::parseFunctionSignature() {
     auto identifier = parseIdentifier();
+    if (!identifier) return nullptr;
 
-    expect(TokenKind::LEFT_PAREN);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::LEFT_PAREN);
     auto parameters = parseCommaSeparatedList<AST::VariableDefinition>(
         TokenKind::RIGHT_PAREN, [this]() { return parseFunctionParameter(); });
-    expect(TokenKind::RIGHT_PAREN);
+    if (!parameters) return nullptr;
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_PAREN);
 
-    const Type returnType =
-        advanceIf(TokenKind::RIGHT_ARROW) ? parseTypeSpecifier() : Type::voidType();
+    const auto returnType = maybeParseTypeAnnotation(TokenKind::RIGHT_ARROW, Type::voidType());
+    if (!returnType) return nullptr;
 
-    return {.identifier_ = std::move(identifier),
-            .parameters_ = std::move(parameters),
-            .returnTypeID_ = typeManager_.createType(returnType)};
+    return std::make_unique<ParsedFunctionSignature>(std::move(identifier),
+                                                     std::move(parameters.value()),
+                                                     typeManager_.createType(returnType.value()));
 }
 
 std::unique_ptr<AST::ExternalFunctionDeclaration> Parser::parseExternalFunctionDeclaration() {
-    const Token& externTok = expect(TokenKind::EXTERN);
-    expect(TokenKind::FN);
+    const Token& externTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::EXTERN);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::FN);
 
-    ParsedFunctionSignature signature = parseFunctionSignature();
+    auto signature = parseFunctionSignature();
+    if (!signature) return nullptr;
 
-    const Token& semi = expect(TokenKind::SEMICOLON);
+    const Token& semi = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
 
     return std::make_unique<AST::ExternalFunctionDeclaration>(
-        std::move(signature.identifier_), std::move(signature.parameters_), signature.returnTypeID_,
-        externTok.byteOffsetStart(), semi.byteOffsetEnd());
+        std::move(signature->identifier_), std::move(signature->parameters_),
+        signature->returnTypeID_, externTok.byteOffsetStart(), semi.byteOffsetEnd());
 }
 
 std::unique_ptr<AST::FunctionDefinition> Parser::parseFunctionDefinition() {
@@ -477,34 +586,53 @@ std::unique_ptr<AST::FunctionDefinition> Parser::parseFunctionDefinition() {
 
     const bool isExported = advanceIf(TokenKind::EXPORT);
 
-    expect(TokenKind::FN);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::FN);
 
-    ParsedFunctionSignature signature = parseFunctionSignature();
+    auto signature = parseFunctionSignature();
+    if (!signature) return nullptr;
 
-    expect(TokenKind::COLON);
+    EXPECT_OR_RETURN_NULLPTR(TokenKind::COLON);
     auto body = parseBlockStatement();
+    if (!body) return nullptr;
+
     return std::make_unique<AST::FunctionDefinition>(
-        std::move(signature.identifier_), std::move(signature.parameters_), signature.returnTypeID_,
-        isExported, std::move(body), sourceStartIndex, body->sourceEndIndex());
+        std::move(signature->identifier_), std::move(signature->parameters_),
+        signature->returnTypeID_, isExported, std::move(body), sourceStartIndex,
+        body->sourceEndIndex());
 }
 
 std::unique_ptr<AST::Program> Parser::parseProgram() {
     auto program = std::make_unique<AST::Program>();
 
+    bool isRecoveringFromError = false;
+
     while (peek().kind() == TokenKind::EXTERN) {
-        auto externFunction = parseExternalFunctionDeclaration();
-        program->appendExternFunction(std::move(externFunction));
-    }
-    while (peek().kind() != TokenKind::EOF_) {
-        if (peek().kind() == TokenKind::FN || peek().kind() == TokenKind::EXPORT) {
-            auto functionDefinition = parseFunctionDefinition();
-            program->appendFunction(std::move(functionDefinition));
+        if (auto externFunction = parseExternalFunctionDeclaration()) {
+            program->appendExternFunction(std::move(externFunction));
         } else {
+            isRecoveringFromError = true;
+            break;
+        }
+    }
+
+    while (peek().kind() != TokenKind::EOF_) {
+        if (isRecoveringFromError) advance();
+
+        if (peek().kind() == TokenKind::FN || peek().kind() == TokenKind::EXPORT) {
+            isRecoveringFromError = false;
+            if (auto functionDefinition = parseFunctionDefinition()) {
+                program->appendFunction(std::move(functionDefinition));
+                continue;
+            }
+        } else if (!isRecoveringFromError) {  // If we are already recovering from an error, avoid
+                                              // spamming errors
             const std::string errorMessage =
                 std::format("Invalid token -> expected function definition, got {}",
                             tokenKindToString(peek().kind()));
-            abort(errorMessage);
+            emitError(errorMessage);
         }
+
+        isRecoveringFromError = true;
     }
 
     return program;

--- a/tests/CompilationError.cpp
+++ b/tests/CompilationError.cpp
@@ -1048,7 +1048,48 @@ TEST_F(NeutroniumTester, InvalidTypeSpecifier) {
                 error2.contains("LITERAL"));
 }
 
-TEST_F(NeutroniumTester, MultipleErrorsAllReported) {
+TEST_F(NeutroniumTester, MultipleParseErrorsAllReported) {
+    {
+        const std::string code = R"(
+        extern fn exit(code: int);
+        extern fn nothing()
+        extern fn read_file(path: str) -> str;
+        extern fn write_file(path: unknown, content: unkown);
+    )";
+        auto [status, error] = compile(code);
+        EXPECT_NE(status, 0);
+
+        EXPECT_TRUE(error.contains("token") && error.contains("EXIT"));
+        EXPECT_TRUE(error.contains("token") && error.contains("SEMICOLON"));
+        EXPECT_TRUE(error.contains("token") && error.contains("type specifier"));
+    }
+
+    {
+        const std::string code = R"(
+            fn main(): {
+               if x == 6: {
+                   while x < 10: {
+                       x = x + 1
+                   }
+               } else: {
+                   exit = 4;
+               }
+
+               y +-
+            }
+            }
+        )";
+        auto [status, error] = compile(code);
+        EXPECT_NE(status, 0);
+
+        EXPECT_TRUE(error.contains("token") && error.contains("SEMICOLON"));
+        EXPECT_TRUE(error.contains("token") && error.contains("EQUAL"));
+        EXPECT_TRUE(error.contains("token") && error.contains("RIGHT_BRACE"));
+        EXPECT_TRUE(error.contains("token") && error.contains("expected FN"));
+    }
+}
+
+TEST_F(NeutroniumTester, MultipleSemaErrorsAllReported) {
     const std::string code = R"(
         extern fn mod(a: int, b: int) -> int;
 


### PR DESCRIPTION
This PR removes the forced "exit" from the parser and instead makes it so functions return nullptr when they encounter an error. It also implements error recovery to allow for multiple parsing error messages at the same time. In addition, the parser no longer aborts which will be useful later so that exits are all at the top level.