### PR TITLE
Implement an arena for AST nodes

### DIFF
--- a/src/ast/AST.hpp
+++ b/src/ast/AST.hpp
@@ -42,7 +42,6 @@ struct Node {
           sourceStartIndex_(sourceStartIndex),
           sourceEndIndex_(sourceEndIndex),
           fileID_(fileID) {}
-    virtual ~Node() = default;
 
     const NodeKind kind_;
 

--- a/src/ast/ASTArena.hpp
+++ b/src/ast/ASTArena.hpp
@@ -28,6 +28,12 @@ class ASTArena {
         return new (mem) T(std::forward<Args>(args)...);
     }
 
+    template <typename T>
+    T* insertArray(const size_t count) {
+        uintptr_t mem = allocate(sizeof(T) * count, alignof(T));
+        return reinterpret_cast<T*>(mem);
+    }
+
    private:
     uintptr_t allocate(const size_t size, const size_t alignment) {
         assert((alignment & (alignment - 1)) == 0 && "Alignment must be power of two");

--- a/src/ast/ASTArena.hpp
+++ b/src/ast/ASTArena.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <new>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/ast/ASTArena.hpp
+++ b/src/ast/ASTArena.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+class ASTArena {
+   public:
+    ASTArena() = default;
+    ~ASTArena() = default;
+
+    template <typename T, typename... Args>
+        requires std::derived_from<T, AST::Node>
+    T* allocate(Args&&... args) {
+        auto node = std::make_unique<T>(std::forward<Args>(args)...);
+        T* ptr = node.get();
+        nodes_.push_back(std::move(node));
+        return ptr;
+    }
+
+    template <typename T, typename... Args>
+        requires std::derived_from<T, AST::Node>
+    const T* allocate(const Args&&... args) {
+        auto node = std::make_unique<T>(std::forward<Args>(args)...);
+        const T* ptr = node.get();
+        nodes_.push_back(std::move(node));
+        return ptr;
+    }
+
+   private:
+    std::vector<std::unique_ptr<AST::Node>> nodes_;
+};

--- a/src/ast/ASTArena.hpp
+++ b/src/ast/ASTArena.hpp
@@ -11,6 +11,7 @@
 
 #include "AST.hpp"
 
+/// An arena allocator for holding AST data. This allows for fast bulk allocation and deallocation.
 class ASTArena {
    public:
     ASTArena() = default;
@@ -27,6 +28,14 @@ class ASTArena {
         }
     }
 
+    /** Insert a new AST node into the arena.
+     *
+     * @tparam T The type of AST node to insert. Must derive from AST::Node and be trivially
+     * destructible.
+     * @tparam Args The types of the constructor arguments for T.
+     * @param args The constructor arguments for T.
+     * @return A pointer to the newly inserted AST node.
+     */
     template <typename T, typename... Args>
         requires std::derived_from<T, AST::Node> && std::is_trivially_destructible_v<T>
     T* insert(Args&&... args) {
@@ -34,6 +43,12 @@ class ASTArena {
         return new (mem) T(std::forward<Args>(args)...);
     }
 
+    /** Insert an array of trivially constructible and destructible objects into the arena.
+     *
+     * @tparam T The type of object to insert. Must be trivially constructible and destructible.
+     * @param count The number of objects to insert.
+     * @return A pointer to the first object in the newly inserted array.
+     */
     template <typename T>
         requires std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>
     T* insertArray(const size_t count) {

--- a/src/ast/Debug.cpp
+++ b/src/ast/Debug.cpp
@@ -219,7 +219,7 @@ void logAst(const Program& programNode) {
     const std::string prefix = "    ";
 
     const auto functionSignature =
-        [&](const Identifier& identifier, const std::vector<VariableDefinition*>& params,
+        [&](const Identifier& identifier, const std::span<VariableDefinition*> params,
             const TypeID returnTypeID, const std::string& newPrefix, const bool hasBody) {
             std::cout << newPrefix << "├── Identifier: " << identifier.name_ << "\n";
             std::cout << newPrefix << "├── ReturnTypeID: " << returnTypeID << "\n";

--- a/src/ast/Debug.cpp
+++ b/src/ast/Debug.cpp
@@ -2,8 +2,8 @@
 
 #include <cassert>
 #include <iostream>
-#include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -219,8 +219,7 @@ void logAst(const Program& programNode) {
     const std::string prefix = "    ";
 
     const auto functionSignature =
-        [&](const Identifier& identifier,
-            const std::vector<std::unique_ptr<VariableDefinition>>& params,
+        [&](const Identifier& identifier, const std::vector<VariableDefinition*>& params,
             const TypeID returnTypeID, const std::string& newPrefix, const bool hasBody) {
             std::cout << newPrefix << "├── Identifier: " << identifier.name_ << "\n";
             std::cout << newPrefix << "├── ReturnTypeID: " << returnTypeID << "\n";

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -8,7 +8,6 @@
 #include <format>
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <print>
 #include <sstream>
 #include <string>
@@ -119,7 +118,7 @@ void compileFile(CompilerOptions opts, SourceManager& sourceManager, const bool 
 
     TypeManager typeManager(diagnosticsEngine);
 
-    const std::unique_ptr<AST::Program> ast = [&] {
+    AST::Program* const ast = [&] {
         const Stage stage("Parsing", verbose);
 
         Parser parser(diagnosticsEngine, fileID, fileContents, typeManager);

--- a/src/driver/main.cpp
+++ b/src/driver/main.cpp
@@ -17,6 +17,7 @@
 
 #include "Cli.hpp"
 #include "ast/AST.hpp"
+#include "ast/ASTArena.hpp"
 #include "ast/Debug.hpp"
 #include "codegen/Generator.hpp"
 #include "diagnostics/DiagnosticsEngine.hpp"
@@ -116,12 +117,13 @@ void compileFile(CompilerOptions opts, SourceManager& sourceManager, const bool 
         return;
     }
 
+    ASTArena astArena;
     TypeManager typeManager(diagnosticsEngine);
 
     AST::Program* const ast = [&] {
         const Stage stage("Parsing", verbose);
 
-        Parser parser(diagnosticsEngine, fileID, fileContents, typeManager);
+        Parser parser(diagnosticsEngine, fileID, fileContents, astArena, typeManager);
         return parser.parse();
     }();
 

--- a/src/parse/Parser.cpp
+++ b/src/parse/Parser.cpp
@@ -142,7 +142,7 @@ std::optional<Type> Parser::maybeParseTypeAnnotation(const TokenKind typeAnnotat
 AST::Identifier* Parser::parseIdentifier() {
     const Token ident = EXPECT_OR_RETURN_NULLPTR(TokenKind::IDENTIFIER);
     return astArena_.insert<AST::Identifier>(ident.lexeme(sourceCode_), ident.byteOffsetStart(),
-                                               ident.byteOffsetEnd(), fileID_, generateAnyType());
+                                             ident.byteOffsetEnd(), fileID_, generateAnyType());
 }
 
 AST::NumberLiteral* Parser::parseNumberLiteral() {
@@ -157,8 +157,8 @@ AST::NumberLiteral* Parser::parseNumberLiteral() {
         return invalidNumberLiteralError(token);
     }
 
-    return astArena_.insert<AST::NumberLiteral>(
-        value, token.byteOffsetStart(), token.byteOffsetEnd(), fileID_, generateAnyType());
+    return astArena_.insert<AST::NumberLiteral>(value, token.byteOffsetStart(),
+                                                token.byteOffsetEnd(), fileID_, generateAnyType());
 }
 
 AST::ArrayLiteral* Parser::parseArrayLiteral() {
@@ -167,9 +167,9 @@ AST::ArrayLiteral* Parser::parseArrayLiteral() {
     if (!elements) return nullptr;
     const Token rBracket = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACKET);
 
-    return astArena_.insert<AST::ArrayLiteral>(
-        std::move(elements.value()), lBracket.byteOffsetStart(), rBracket.byteOffsetEnd(), fileID_,
-        generateAnyType());
+    return astArena_.insert<AST::ArrayLiteral>(std::move(elements.value()),
+                                               lBracket.byteOffsetStart(), rBracket.byteOffsetEnd(),
+                                               fileID_, generateAnyType());
 }
 
 AST::Expression* Parser::parseIdentifierOrFunctionCall() {
@@ -183,9 +183,9 @@ AST::Expression* Parser::parseIdentifierOrFunctionCall() {
         const Token rParen = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_PAREN);
 
         const uint32_t startIndex = ident->sourceStartIndex();
-        return astArena_.insert<AST::FunctionCall>(ident, std::move(arguments.value()),
-                                                     startIndex, rParen.byteOffsetEnd(), fileID_,
-                                                     generateAnyType());
+        return astArena_.insert<AST::FunctionCall>(ident, std::move(arguments.value()), startIndex,
+                                                   rParen.byteOffsetEnd(), fileID_,
+                                                   generateAnyType());
     } else {
         // Identifier
         return ident;
@@ -200,7 +200,7 @@ AST::ArrayAccess* Parser::parseArrayAccess(const AST::Expression* base) {
 
     const uint32_t startIndex = base->sourceStartIndex();
     return astArena_.insert<AST::ArrayAccess>(base, index, startIndex, rBracket.byteOffsetEnd(),
-                                                fileID_, generateAnyType());
+                                              fileID_, generateAnyType());
 }
 
 AST::Expression* Parser::parsePrimaryExpression() {
@@ -266,7 +266,7 @@ AST::Expression* Parser::parseUnaryExpression() {
 
         const uint32_t endIndex = operand->sourceEndIndex();
         return astArena_.insert<AST::UnaryExpression>(op, operand, token.byteOffsetStart(),
-                                                        endIndex, fileID_, generateAnyType());
+                                                      endIndex, fileID_, generateAnyType());
     }
 
     return parsePostfixExpression();
@@ -289,7 +289,7 @@ AST::Expression* Parser::parseBinaryExpression(
         const uint32_t startIndex = left->sourceStartIndex();
         const uint32_t endIndex = right->sourceEndIndex();
         left = astArena_.insert<AST::BinaryExpression>(left, op, right, startIndex, endIndex,
-                                                         fileID_, generateAnyType());
+                                                       fileID_, generateAnyType());
         if (!allowMultiple) break;
     }
 
@@ -356,13 +356,13 @@ AST::Statement* Parser::parseAssignmentOrExpressionStatement() {
 
         const uint32_t startIndex = expression->sourceStartIndex();
         return astArena_.insert<AST::Assignment>(expression, op, right, startIndex,
-                                                   semi.byteOffsetEnd(), fileID_);
+                                                 semi.byteOffsetEnd(), fileID_);
     } else {
         // Expression statement
         const Token semi = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
         const uint32_t startIndex = expression->sourceStartIndex();
         return astArena_.insert<AST::ExpressionStatement>(expression, startIndex,
-                                                            semi.byteOffsetEnd(), fileID_);
+                                                          semi.byteOffsetEnd(), fileID_);
     }
 }
 
@@ -407,7 +407,7 @@ AST::IfStatement* Parser::parseIfOrElif(const TokenKind kind) {
 
     const uint32_t endIndex = elseClause ? elseClause->sourceEndIndex() : body->sourceEndIndex();
     return astArena_.insert<AST::IfStatement>(condition, body, elseClause,
-                                                keywordTok.byteOffsetStart(), endIndex, fileID_);
+                                              keywordTok.byteOffsetStart(), endIndex, fileID_);
 }
 
 AST::IfStatement* Parser::parseIfStatement() { return parseIfOrElif(TokenKind::IF); }
@@ -425,21 +425,21 @@ AST::WhileStatement* Parser::parseWhileStatement() {
 
     const uint32_t endIndex = body->sourceEndIndex();
     return astArena_.insert<AST::WhileStatement>(condition, body, whileTok.byteOffsetStart(),
-                                                   endIndex, fileID_);
+                                                 endIndex, fileID_);
 }
 
 AST::BreakStatement* Parser::parseBreakStatement() {
     const Token breakTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::BREAK);
     const Token semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return astArena_.insert<AST::BreakStatement>(breakTok.byteOffsetStart(),
-                                                   semiTok.byteOffsetEnd(), fileID_);
+                                                 semiTok.byteOffsetEnd(), fileID_);
 }
 
 AST::ContinueStatement* Parser::parseContinueStatement() {
     const Token continueTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::CONTINUE);
     const Token semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return astArena_.insert<AST::ContinueStatement>(continueTok.byteOffsetStart(),
-                                                      semiTok.byteOffsetEnd(), fileID_);
+                                                    semiTok.byteOffsetEnd(), fileID_);
 }
 
 AST::ReturnStatement* Parser::parseReturnStatement() {
@@ -454,7 +454,7 @@ AST::ReturnStatement* Parser::parseReturnStatement() {
     const Token semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
 
     return astArena_.insert<AST::ReturnStatement>(returnValue, returnTok.byteOffsetStart(),
-                                                    semiTok.byteOffsetEnd(), fileID_);
+                                                  semiTok.byteOffsetEnd(), fileID_);
 }
 
 AST::ExitStatement* Parser::parseExitStatement() {
@@ -463,7 +463,7 @@ AST::ExitStatement* Parser::parseExitStatement() {
     if (!exitCode) return nullptr;
     const Token semiTok = EXPECT_OR_RETURN_NULLPTR(TokenKind::SEMICOLON);
     return astArena_.insert<AST::ExitStatement>(exitCode, exitTok.byteOffsetStart(),
-                                                  semiTok.byteOffsetEnd(), fileID_);
+                                                semiTok.byteOffsetEnd(), fileID_);
 }
 
 AST::BlockStatement* Parser::parseBlockStatement() {
@@ -495,7 +495,7 @@ AST::BlockStatement* Parser::parseBlockStatement() {
     const Token rBrace = EXPECT_OR_RETURN_NULLPTR(TokenKind::RIGHT_BRACE);
 
     return astArena_.insert<AST::BlockStatement>(std::move(statements), lBrace.byteOffsetStart(),
-                                                   rBrace.byteOffsetEnd(), fileID_);
+                                                 rBrace.byteOffsetEnd(), fileID_);
 }
 
 AST::Statement* Parser::parseStatement() {
@@ -528,7 +528,7 @@ AST::VariableDefinition* Parser::parseFunctionParameter() {
 
     const uint32_t endIndex = identifier->sourceEndIndex();
     return astArena_.insert<AST::VariableDefinition>(identifier, typeID, isMutable,
-                                                       sourceStartIndex, endIndex, fileID_);
+                                                     sourceStartIndex, endIndex, fileID_);
 }
 
 std::unique_ptr<ParsedFunctionSignature> Parser::parseFunctionSignature() {

--- a/src/parse/Parser.cpp
+++ b/src/parse/Parser.cpp
@@ -32,7 +32,7 @@
 #endif
 
 AST::Program* Parser::parse() {
-    auto ast = parseProgram();
+    const auto ast = parseProgram();
 
     if (diagnosticsEngine_.hasErrors()) {
         diagnosticsEngine_.emit();
@@ -583,10 +583,10 @@ AST::FunctionDefinition* Parser::parseFunctionDefinition() {
 }
 
 AST::Program* Parser::parseProgram() {
-    auto program = astArena_.allocate<AST::Program>(fileID_);
+    const auto program = astArena_.allocate<AST::Program>(fileID_);
 
     while (peek().kind() == TokenKind::EXTERN) {
-        if (auto externFunction = parseExternalFunctionDeclaration()) {
+        if (const auto externFunction = parseExternalFunctionDeclaration()) {
             program->appendExternFunction(externFunction);
         } else {
             // Error recovery: skip to the next semicolon
@@ -598,7 +598,7 @@ AST::Program* Parser::parseProgram() {
     }
 
     while (peek().kind() != TokenKind::EOF_) {
-        if (auto functionDefinition = parseFunctionDefinition()) {
+        if (const auto functionDefinition = parseFunctionDefinition()) {
             program->appendFunction(functionDefinition);
 
         } else {

--- a/src/parse/Parser.hpp
+++ b/src/parse/Parser.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstring>
 #include <functional>
 #include <initializer_list>
+#include <memory>
 #include <optional>
 #include <span>
 #include <string>

--- a/src/parse/Parser.hpp
+++ b/src/parse/Parser.hpp
@@ -2,13 +2,13 @@
 
 #include <functional>
 #include <initializer_list>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "ast/AST.hpp"
+#include "ast/ASTArena.hpp"
 #include "ast/Operator.hpp"
 #include "diagnostics/DiagnosticsEngine.hpp"
 #include "lex/Lexer.hpp"
@@ -20,8 +20,8 @@
 #include "type/TypeManager.hpp"
 
 struct ParsedFunctionSignature {
-    std::unique_ptr<AST::Identifier> identifier_;
-    std::vector<std::unique_ptr<AST::VariableDefinition>> parameters_;
+    AST::Identifier* identifier_;
+    std::vector<AST::VariableDefinition*> parameters_;
     TypeID returnTypeID_;
 };
 
@@ -37,7 +37,7 @@ class Parser {
         token_ = lexer_.lex();
     }
 
-    [[nodiscard]] std::unique_ptr<AST::Program> parse();
+    [[nodiscard]] AST::Program* parse();
 
    private:
     Lexer lexer_;
@@ -45,6 +45,8 @@ class Parser {
     DiagnosticsEngine& diagnosticsEngine_;
     FileID fileID_;
     std::string_view sourceCode_;
+
+    ASTArena astArena_;
 
     TypeManager& typeManager_;
 
@@ -64,8 +66,8 @@ class Parser {
      * @return nullptr of type T.
      */
     template <class T>
-    [[nodiscard]] std::unique_ptr<T> emitError(const std::string& errorMessage,
-                                               const Token token) const {
+    [[nodiscard]] T* emitError(const std::string& errorMessage,
+                               const Token token) const {
         emitError(errorMessage, token);
         return nullptr;
     }
@@ -75,14 +77,14 @@ class Parser {
      * @return nullptr of type T.
      */
     template <class T>
-    [[nodiscard]] std::unique_ptr<T> emitError(const std::string& errorMessage) const {
+    [[nodiscard]] T* emitError(const std::string& errorMessage) const {
         return emitError<T>(errorMessage, peek());
     }
 
     void expectError(TokenKind expected) const;
     [[nodiscard]] std::unique_ptr<Type> invalidTypeSpecifierError() const;
-    [[nodiscard]] std::unique_ptr<AST::Expression> invalidPrimaryExpressionError() const;
-    [[nodiscard]] std::unique_ptr<AST::NumberLiteral> invalidNumberLiteralError(
+    [[nodiscard]] AST::Expression* invalidPrimaryExpressionError() const;
+    [[nodiscard]] AST::NumberLiteral* invalidNumberLiteralError(
         const Token& token) const;
 
     // ---------------
@@ -104,9 +106,9 @@ class Parser {
     }
 
     template <class T>
-    std::optional<std::vector<std::unique_ptr<T>>> parseCommaSeparatedList(
-        TokenKind endDelimiter, const std::function<std::unique_ptr<T>()>& parseElement);
-    std::optional<std::vector<std::unique_ptr<AST::Expression>>> parseExpressionList(
+    std::optional<std::vector<T*>> parseCommaSeparatedList(
+        TokenKind endDelimiter, const std::function<T*()>& parseElement);
+    std::optional<std::vector<AST::Expression*>> parseExpressionList(
         TokenKind endDelimiter);
 
     static std::optional<Type> tryParsePrimitiveType(TokenKind tokenKind);
@@ -118,43 +120,43 @@ class Parser {
     std::optional<Type> maybeParseTypeAnnotation(TokenKind typeAnnotationIndicator,
                                                  Type defaultType);
 
-    std::unique_ptr<AST::NumberLiteral> parseNumberLiteral();
-    std::unique_ptr<AST::ArrayLiteral> parseArrayLiteral();
+    AST::NumberLiteral* parseNumberLiteral();
+    AST::ArrayLiteral* parseArrayLiteral();
 
-    std::unique_ptr<AST::Identifier> parseIdentifier();
-    std::unique_ptr<AST::Expression> parseIdentifierOrFunctionCall();
-    std::unique_ptr<AST::ArrayAccess> parseArrayAccess(std::unique_ptr<AST::Expression> base);
-    std::unique_ptr<AST::Expression> parsePrimaryExpression();
-    std::unique_ptr<AST::Expression> parsePostfixExpression();
-    std::unique_ptr<AST::Expression> parseUnaryExpression();
-    std::unique_ptr<AST::Expression> parseBinaryExpression(
-        const std::function<std::unique_ptr<AST::Expression>()>& parseOperand,
+    AST::Identifier* parseIdentifier();
+    AST::Expression* parseIdentifierOrFunctionCall();
+    AST::ArrayAccess* parseArrayAccess(const AST::Expression* base);
+    AST::Expression* parsePrimaryExpression();
+    AST::Expression* parsePostfixExpression();
+    AST::Expression* parseUnaryExpression();
+    AST::Expression* parseBinaryExpression(
+        const std::function<AST::Expression*()>& parseOperand,
         std::initializer_list<AST::Operator> allowedOps, bool allowMultiple);
-    std::unique_ptr<AST::Expression> parseMultiplicativeExpression();
-    std::unique_ptr<AST::Expression> parseAdditiveExpression();
-    std::unique_ptr<AST::Expression> parseComparisonExpression();
-    std::unique_ptr<AST::Expression> parseExpression();
+    AST::Expression* parseMultiplicativeExpression();
+    AST::Expression* parseAdditiveExpression();
+    AST::Expression* parseComparisonExpression();
+    AST::Expression* parseExpression();
 
-    std::unique_ptr<AST::VariableDefinition> parseVariableDefinition();
-    std::unique_ptr<AST::Statement> parseAssignmentOrExpressionStatement();
+    AST::VariableDefinition* parseVariableDefinition();
+    AST::Statement* parseAssignmentOrExpressionStatement();
 
-    std::unique_ptr<AST::BlockStatement> parseElseClause();
-    std::unique_ptr<AST::IfStatement> parseIfOrElif(TokenKind kind);
-    std::unique_ptr<AST::IfStatement> parseIfStatement();
-    std::unique_ptr<AST::WhileStatement> parseWhileStatement();
+    AST::BlockStatement* parseElseClause();
+    AST::IfStatement* parseIfOrElif(TokenKind kind);
+    AST::IfStatement* parseIfStatement();
+    AST::WhileStatement* parseWhileStatement();
 
-    std::unique_ptr<AST::VariableDefinition> parseFunctionParameter();
-    std::unique_ptr<AST::BreakStatement> parseBreakStatement();
-    std::unique_ptr<AST::ContinueStatement> parseContinueStatement();
-    std::unique_ptr<AST::ReturnStatement> parseReturnStatement();
-    std::unique_ptr<AST::ExitStatement> parseExitStatement();
-    std::unique_ptr<AST::BlockStatement> parseBlockStatement();
+    AST::VariableDefinition* parseFunctionParameter();
+    AST::BreakStatement* parseBreakStatement();
+    AST::ContinueStatement* parseContinueStatement();
+    AST::ReturnStatement* parseReturnStatement();
+    AST::ExitStatement* parseExitStatement();
+    AST::BlockStatement* parseBlockStatement();
 
-    std::unique_ptr<AST::Statement> parseStatement();
+    AST::Statement* parseStatement();
 
     std::unique_ptr<ParsedFunctionSignature> parseFunctionSignature();
-    std::unique_ptr<AST::ExternalFunctionDeclaration> parseExternalFunctionDeclaration();
+    AST::ExternalFunctionDeclaration* parseExternalFunctionDeclaration();
 
-    std::unique_ptr<AST::FunctionDefinition> parseFunctionDefinition();
-    std::unique_ptr<AST::Program> parseProgram();
+    AST::FunctionDefinition* parseFunctionDefinition();
+    AST::Program* parseProgram();
 };

--- a/src/parse/Parser.hpp
+++ b/src/parse/Parser.hpp
@@ -115,7 +115,7 @@ class Parser {
     template <typename T>
         requires std::is_trivially_copyable_v<T>
     [[nodiscard]] std::span<T> insertVector(std::vector<T>&& vec) {
-        if (vec.size() == 0) return {};
+        if (vec.empty()) return {};
 
         T* data = astArena_.insertArray<T>(vec.size());
         std::memcpy(reinterpret_cast<void*>(data), vec.data(), vec.size() * sizeof(T));

--- a/src/parse/Parser.hpp
+++ b/src/parse/Parser.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <initializer_list>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -102,6 +103,21 @@ class Parser {
      */
     [[nodiscard]] TypeID generateAnyType() const {
         return typeManager_.createType(Type::anyFamilyType());
+    }
+
+    /** Inserts a vector into the ASTArena and returns a span to it.
+     * @tparam T The type of the elements in the vector.
+     * @param vec The vector to insert.
+     * @return A span to the inserted vector.
+     */
+    template <typename T>
+        requires std::is_trivially_copyable_v<T>
+    [[nodiscard]] std::span<T> insertVector(std::vector<T>&& vec) {
+        if (vec.size() == 0) return {};
+
+        T* data = astArena_.insertArray<T>(vec.size());
+        std::memcpy(reinterpret_cast<void*>(data), vec.data(), vec.size() * sizeof(T));
+        return {data, vec.size()};
     }
 
     template <class T>

--- a/src/parse/ParsingError.cpp
+++ b/src/parse/ParsingError.cpp
@@ -27,11 +27,10 @@ __attribute__((noinline, cold)) std::unique_ptr<Type> Parser::invalidTypeSpecifi
 
     const std::string errorMessage = std::format("Invalid token -> expected type specifier, got {}",
                                                  tokenKindToString(tokenKind));
-    return emitError<Type>(errorMessage);
+    return std::unique_ptr<Type>(emitError<Type>(errorMessage));
 }
 
-__attribute__((noinline, cold)) std::unique_ptr<AST::Expression>
-Parser::invalidPrimaryExpressionError() const {
+__attribute__((noinline, cold)) AST::Expression* Parser::invalidPrimaryExpressionError() const {
     const Token& token = peek();
 
     const std::string errorMessage =
@@ -40,8 +39,8 @@ Parser::invalidPrimaryExpressionError() const {
     return emitError<AST::Expression>(errorMessage);
 }
 
-__attribute__((noinline, cold)) std::unique_ptr<AST::NumberLiteral>
-Parser::invalidNumberLiteralError(const Token& token) const {
+__attribute__((noinline, cold)) AST::NumberLiteral* Parser::invalidNumberLiteralError(
+    const Token& token) const {
     const std::string errorMessage = "Invalid number literal";
     return emitError<AST::NumberLiteral>(errorMessage, token);
 }

--- a/src/sema/SemanticAnalyser.cpp
+++ b/src/sema/SemanticAnalyser.cpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <optional>
 #include <ranges>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -158,7 +159,7 @@ SymbolInfo& SemanticAnalyser::declareSymbol(const AST::Node* declarationNode,
 
 SymbolInfo& SemanticAnalyser::handleFunctionDeclaration(
     const AST::Node* declNode, const std::string_view name, const TypeID returnTypeID,
-    const std::vector<AST::VariableDefinition*>& params) {
+    const std::span<AST::VariableDefinition*> params) {
     std::vector<SymbolInfo> parameterSymbols;
     for (const auto* param : params) {
         const TypeID paramType = param->typeID_;

--- a/src/sema/SemanticAnalyser.cpp
+++ b/src/sema/SemanticAnalyser.cpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <cstdlib>
 #include <format>
-#include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -50,9 +49,9 @@ void SemanticAnalyser::analyse() {
     }
 
     const AST::FunctionDefinition* mainDef = nullptr;
-    for (const auto& funcDef : ast_->functions_) {
+    for (const auto* funcDef : ast_->functions_) {
         if (funcDef->identifier_->name_ == ENTRY_POINT_NAME) {
-            mainDef = funcDef.get();
+            mainDef = funcDef;
             break;
         }
     }
@@ -159,12 +158,12 @@ SymbolInfo& SemanticAnalyser::declareSymbol(const AST::Node* declarationNode,
 
 SymbolInfo& SemanticAnalyser::handleFunctionDeclaration(
     const AST::Node* declNode, const std::string_view name, const TypeID returnTypeID,
-    const std::vector<std::unique_ptr<AST::VariableDefinition>>& params) {
+    const std::vector<AST::VariableDefinition*>& params) {
     std::vector<SymbolInfo> parameterSymbols;
-    for (const auto& param : params) {
+    for (const auto* param : params) {
         const TypeID paramType = param->typeID_;
-        parameterSymbols.emplace_back(handleVariableDeclaration(
-            param.get(), param->identifier_->name_, param->isMutable_, paramType));
+        parameterSymbols.emplace_back(handleVariableDeclaration(param, param->identifier_->name_,
+                                                                param->isMutable_, paramType));
     }
 
     return declareSymbol(declNode, name, SymbolKind::FUNCTION, false, returnTypeID, false,
@@ -257,7 +256,7 @@ TypeID SemanticAnalyser::checkExpression(const AST::Expression& expr) {
             }
 
             const TypeID elementTypeID = checkExpression(*arrayLiteral.elements_[0]);
-            for (const auto& element : arrayLiteral.elements_ | std::views::drop(1)) {
+            for (const auto* element : arrayLiteral.elements_ | std::views::drop(1)) {
                 checkExpression(*element, elementTypeID);
             }
 
@@ -359,7 +358,7 @@ bool SemanticAnalyser::verifyIsAssignable(const AST::Expression& expr) {
 }
 
 void SemanticAnalyser::analyseAssignment(const AST::Assignment& assignment) {
-    const auto& place = assignment.place_;
+    const auto* place = assignment.place_;
 
     if (!verifyIsAssignable(*place)) {
         // If the place is not assignable, we cannot proceed further.
@@ -468,7 +467,7 @@ void SemanticAnalyser::analyseStatement(const AST::Statement& stmt) {
         case AST::NodeKind::BLOCK_STATEMENT: {
             const auto& blockStmt = *stmt.as<AST::BlockStatement>();
             const ScopeGuard guard(*this);
-            for (const auto& innerStmt : blockStmt.body_) {
+            for (const auto* innerStmt : blockStmt.body_) {
                 analyseStatement(*innerStmt);
             }
             break;
@@ -491,7 +490,7 @@ bool SemanticAnalyser::verifyStatementReturns(const AST::Statement& stmt) {
 
     } else if (kind == AST::NodeKind::BLOCK_STATEMENT) {
         const auto& blockStmt = *stmt.as<AST::BlockStatement>();
-        for (const auto& innerStmt : blockStmt.body_) {
+        for (const auto* innerStmt : blockStmt.body_) {
             if (verifyStatementReturns(*innerStmt)) return true;
         }
 

--- a/src/sema/SemanticAnalyser.hpp
+++ b/src/sema/SemanticAnalyser.hpp
@@ -110,7 +110,7 @@ class SemanticAnalyser {
 
     SymbolInfo& handleFunctionDeclaration(const AST::Node* declNode, std::string_view name,
                                           TypeID returnTypeID,
-                                          const std::vector<AST::VariableDefinition*>& params);
+                                          std::span<AST::VariableDefinition*> params);
     SymbolInfo& handleVariableDeclaration(const AST::VariableDefinition* declNode,
                                           std::string_view name, bool isMutable, TypeID typeID);
 

--- a/src/sema/SemanticAnalyser.hpp
+++ b/src/sema/SemanticAnalyser.hpp
@@ -108,9 +108,9 @@ class SemanticAnalyser {
                               SymbolKind kind, bool isMutable, TypeID typeID, bool isScoped,
                               std::vector<SymbolInfo> parameters);
 
-    SymbolInfo& handleFunctionDeclaration(
-        const AST::Node* declNode, std::string_view name, TypeID returnTypeID,
-        const std::vector<std::unique_ptr<AST::VariableDefinition>>& params);
+    SymbolInfo& handleFunctionDeclaration(const AST::Node* declNode, std::string_view name,
+                                          TypeID returnTypeID,
+                                          const std::vector<AST::VariableDefinition*>& params);
     SymbolInfo& handleVariableDeclaration(const AST::VariableDefinition* declNode,
                                           std::string_view name, bool isMutable, TypeID typeID);
 


### PR DESCRIPTION
This PR significantly improves parsing time by using an arena to store AST data, instead of individual std::unique_ptr allocations and deallocations.