### PR TITLE
Optimize Type memory usage

### DIFF
--- a/src/ast/AST.hpp
+++ b/src/ast/AST.hpp
@@ -39,11 +39,9 @@ struct Node {
     Node(const NodeKind kind, const uint32_t sourceStartIndex, const uint32_t sourceEndIndex,
          const FileID fileID)
         : kind_(kind),
+          fileID_(fileID),
           sourceStartIndex_(sourceStartIndex),
-          sourceEndIndex_(sourceEndIndex),
-          fileID_(fileID) {}
-
-    const NodeKind kind_;
+          sourceEndIndex_(sourceEndIndex) {}
 
     [[nodiscard]] uint32_t sourceStartIndex() const { return sourceStartIndex_; }
     [[nodiscard]] uint32_t sourceEndIndex() const { return sourceEndIndex_; }
@@ -58,10 +56,13 @@ struct Node {
         return static_cast<const T*>(this);
     }
 
+    const NodeKind kind_;
+
    protected:
+    const FileID fileID_;
+
     uint32_t sourceStartIndex_;
     uint32_t sourceEndIndex_;
-    const FileID fileID_;
 };
 
 struct Expression : Node {

--- a/src/source/FileID.hpp
+++ b/src/source/FileID.hpp
@@ -2,4 +2,4 @@
 
 #include <cstddef>
 
-using FileID = std::size_t;
+using FileID = std::uint16_t;

--- a/src/type/Primitive.hpp
+++ b/src/type/Primitive.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 #include <utility>
-#include <vector>
 
 #include "Trait.hpp"
 
@@ -18,19 +18,22 @@ enum class Kind : uint8_t {
     VOID,
 };
 
-inline std::vector<Trait> defaultTraits(const Kind kind) {
+inline uint16_t defaultTraits(const Kind kind) {
+    static_assert(std::is_same_v<std::underlying_type_t<Trait>, uint16_t>,
+                  "Trait underlying type must be uint16_t");
+
     switch (kind) {
         case Kind::INT:
         case Kind::INT8:
         case Kind::INT16:
         case Kind::INT32:
         case Kind::INT64:
-            return std::vector{Trait::ADD, Trait::SUB, Trait::MUL, Trait::DIV, Trait::EQ,
-                               Trait::LT,  Trait::LTE, Trait::GT,  Trait::GTE};
+            return Trait::ADD | Trait::SUB | Trait::MUL | Trait::DIV | Trait::EQ | Trait::LT |
+                   Trait::LTE | Trait::GT | Trait::GTE;
         case Kind::BOOL:
-            return std::vector{Trait::EQ, Trait::NOT};
+            return Trait::EQ | Trait::NOT;
         case Kind::VOID:
-            return std::vector<Trait>{};
+            return 0;
     }
 
     std::unreachable();

--- a/src/type/Trait.cpp
+++ b/src/type/Trait.cpp
@@ -3,6 +3,7 @@
 #include <magic_enum/magic_enum.hpp>
 #include <optional>
 #include <string_view>
+#include <utility>
 
 #include "ast/Operator.hpp"
 

--- a/src/type/Trait.hpp
+++ b/src/type/Trait.hpp
@@ -2,29 +2,38 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
+#include <string_view>
+#include <type_traits>
 
 #include "ast/Operator.hpp"
 
-enum class Trait : uint8_t {
+enum class Trait : uint16_t {
     // Arithmetic traits
-    ADD,
-    SUB,
-    MUL,
-    DIV,
+    ADD = 1 << 0,
+    SUB = 1 << 1,
+    MUL = 1 << 2,
+    DIV = 1 << 3,
 
     // Logical traits
-    NOT,
+    NOT = 1 << 4,
 
     // Comparison traits
-    EQ,
-    LT,
-    LTE,
-    GT,
-    GTE,
+    EQ = 1 << 5,
+    LT = 1 << 6,
+    LTE = 1 << 7,
+    GT = 1 << 8,
+    GTE = 1 << 9,
 
-    SUBSCRIPT,
+    SUBSCRIPT = 1 << 10,
 };
+
+inline uint16_t operator|(Trait a, Trait b) {
+    return static_cast<uint16_t>(a) | static_cast<uint16_t>(b);
+}
+
+inline uint16_t operator|(const std::underlying_type_t<Trait> a, Trait b) {
+    return a | static_cast<std::underlying_type_t<Trait>>(b);
+}
 
 [[nodiscard]] std::optional<Trait> traitFromOperator(AST::Operator op);
 

--- a/src/type/Type.hpp
+++ b/src/type/Type.hpp
@@ -24,7 +24,7 @@ enum class TypeKind : uint8_t {
  *
  * The `Type` class provides functionality to define and manage different types, such as
  * primitive types (e.g., integers, booleans) or array types. It supports initialization
- * with various constructors and supports the concept of type families for primitive types².
+ * with various constructors and supports the concept of type families for primitive types.
  */
 class Type {
    public:

--- a/src/type/TypeArena.hpp
+++ b/src/type/TypeArena.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "Type.hpp"

--- a/src/type/inference/TypeSolver.cpp
+++ b/src/type/inference/TypeSolver.cpp
@@ -46,8 +46,6 @@ bool TypeSolver::unify(const TypeID dst, const TypeID src, const AST::Node& sour
     if (dstType.kind() != srcType.kind()) return false;
 
     switch (dstType.kind()) {
-        case TypeKind::UNKNOWN:
-            std::unreachable();
         case TypeKind::PRIMITIVE:
             return dstType.mergeWith(srcType, typeManager_);
         case TypeKind::ARRAY: {
@@ -56,8 +54,9 @@ bool TypeSolver::unify(const TypeID dst, const TypeID src, const AST::Node& sour
                 dstType.arrayElementTypeId(), srcType.arrayElementTypeId(), sourceNode);
             return true;
         }
+        default:
+            std::unreachable();
     }
-    std::unreachable();
 }
 
 void TypeSolver::prepareUnionFind() {


### PR DESCRIPTION
This PR significantly improves parsing time and overall memory usage by optimizing the `Type` class. It replaces a vector of traits with a 2-byte bitmask, and avoids wasted memory due to padding.